### PR TITLE
Fix Compiling with HIP on Older Pytorch Version

### DIFF
--- a/exllamav2/exllamav2_ext/cuda/q_gemm.cu
+++ b/exllamav2/exllamav2_ext/cuda/q_gemm.cu
@@ -41,6 +41,10 @@ __host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(hipblasHandle_t  
                         reinterpret_cast<hipblasHalf *>(CP), ldc);
 }
 #define hipblasHgemm __compat_hipblasHgemm
+
+// Previous version of PyTorch were converting to rocBLAS instead of hipBLAS.
+#define rocblas_operation_none HIPBLAS_OP_N
+#define rocblas_hgemm __compat_hipblasHgemm
 #endif
 
 void gemm_half_q_half_cuda_part


### PR DESCRIPTION
Hit a compiling issue when running the model with Rocm.
```
Traceback (most recent call last):
  File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1900, in _run_ninja_build
    subprocess.run(
  File "/opt/conda/envs/py_3.9/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v', '-j', '8']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/lib/jenkins/text-generation-webui/repositories/exllamav2/test_inference.py", line 2, in <module>
    from exllamav2 import(
  File "/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/__init__.py", line 3, in <module>
    from exllamav2.model import ExLlamaV2
  File "/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/model.py", line 12, in <module>
    from exllamav2.linear import ExLlamaV2Linear
  File "/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/linear.py", line 4, in <module>
    from exllamav2 import ext
  File "/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/ext.py", line 118, in <module>
    exllamav2_ext = load \
  File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1283, in load
    return _jit_compile(
  File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1508, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1623, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1916, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'exllamav2_ext': [1/2] /opt/rocm/bin/hipcc  -DWITH_HIP -DTORCH_EXTENSION_NAME=exllamav2_ext -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1013\" -I/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/exllamav2_ext -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/torch/csrc/api/include -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/TH -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/THC -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/THH -isystem /opt/rocm/include -isystem /opt/conda/envs/py_3.9/include/python3.9 -D_GLIBCXX_USE_CXX11_ABI=1 -fPIC -std=c++17 -O3 -fPIC -D__HIP_PLATFORM_HCC__=1 -DUSE_ROCM=1 -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -lineinfo -O3 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942 -fno-gpu-rdc -c /var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/exllamav2_ext/hip/q_gemm.hip -o q_gemm.cuda.o
FAILED: q_gemm.cuda.o
/opt/rocm/bin/hipcc  -DWITH_HIP -DTORCH_EXTENSION_NAME=exllamav2_ext -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1013\" -I/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/exllamav2_ext -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/torch/csrc/api/include -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/TH -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/THC -isystem /opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/include/THH -isystem /opt/rocm/include -isystem /opt/conda/envs/py_3.9/include/python3.9 -D_GLIBCXX_USE_CXX11_ABI=1 -fPIC -std=c++17 -O3 -fPIC -D__HIP_PLATFORM_HCC__=1 -DUSE_ROCM=1 -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -lineinfo -O3 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942 -fno-gpu-rdc -c /var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/exllamav2_ext/hip/q_gemm.hip -o q_gemm.cuda.o
clang: warning: -lineinfo: 'linker' input unused [-Wunused-command-line-argument]
/var/lib/jenkins/text-generation-webui/repositories/exllamav2/exllamav2/exllamav2_ext/hip/q_gemm.hip:156:9: error: no matching function for call to 'rocblas_hgemm'
        rocblas_hgemm(cublas_handle,
        ^~~~~~~~~~~~~
```
Adding addtional define fix the issue.