### PR TITLE
Build wheels with pre-compiled CUDA kernels

### DIFF
--- a/.github/workflows/build-wheels-release-rocm.yml
+++ b/.github/workflows/build-wheels-release-rocm.yml
@@ -1,0 +1,109 @@
+name: Build ROCm 5.4.2 Wheels & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      pypi:
+        description: 'Upload wheels to PyPI? 1 = yes, 0 = no'
+        default: '1'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      pypi:
+        description: 'Upload wheels to PyPI? 1 = yes, 0 = no'
+        default: '0'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build ROCm wheel for Python ${{ matrix.pyver }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        pyver: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.2.0
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+    
+      - uses: actions/checkout@v3
+          
+      - name: Install ROCm SDK
+        run: |
+          export ROCM_VERSION=5.6
+          
+          [ ! -d /etc/apt/keyrings ] && sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+          wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ROCM_VERSION focal main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
+          echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+          sudo apt update
+          sudo apt install rocm-hip-sdk -y
+          echo "/opt/rocm/bin" >> $GITHUB_PATH
+          echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
+          echo "ROCM_VERSION=$ROCM_VERSION" >> $GITHUB_ENV
+          echo "USE_ROCM=1" >> $GITHUB_ENV
+          
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.pyver }}
+          
+      - name: Install Dependencies
+        run: |
+          pip3 install torch\<=2.1.0 --pre --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION" --extra-index-url="https://download.pytorch.org/whl/nightly/rocm$ROCM_VERSION"
+          pip3 install build wheel safetensors sentencepiece ninja
+        
+      - name: Build Wheel
+        id: build-wheel
+        run: |
+          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(') {Write-Output $('::notice file=build-wheels-release-rocm.yml,line=54,title=Package Version::Detected package version is: {0}' -f $Matches[1]); Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"} else {Write-Output '::error file=build-wheels-release.yml,line=41::Could not parse version from setup.py! You must upload wheels manually!'; Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"}
+          $BUILDTAG = "+rocm$env:ROCM_VERSION"
+          python3 -m build -n --wheel -C--build-option=egg_info "-C--build-option=--tag-build=$BUILDTAG"
+        shell: pwsh
+        
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'wheels'
+          path: ./dist/*.whl
+          
+      - name: Upload files to a GitHub release
+        if: steps.build-wheel.outputs.PACKAGE_VERSION != 'None'
+        uses: svenstaro/upload-release-action@2.6.1
+        with:
+          file: ./dist/*.whl
+          tag: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          file_glob: true
+          overwrite: true
+          release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+      
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: inputs.pypi == '1' && github.event_name != 'workflow_call'
+    needs: ['build_wheels','build_rocm']
+    runs-on: ubuntu-latest
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/exllamav2
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      
+    steps:
+      - name: Download all the wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -101,6 +101,13 @@ jobs:
           file_glob: true
           overwrite: true
           release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          
+  build_rocm:
+    name: Build ROCm Wheels & Release
+    needs: build_wheels
+    uses: ./.github/workflows/build-wheels-release-rocm.yml
+    with:
+      pypi: '0'
       
   publish-wheels-to-pypi:
     name: Publish Python distribution to PyPI

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -1,0 +1,126 @@
+name: Build Wheels & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      pypi:
+        description: 'Upload wheels to PyPI? 1 = yes, 0 = no'
+        default: '1'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: ${{ matrix.os }} Python ${{ matrix.pyver }} CUDA ${{ matrix.cuda }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-latest]
+        pyver: ["3.8", "3.9", "3.10", "3.11"]
+        cuda: ["11.7.0", "11.8.0", "12.1.1"]
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CUDAVER: ${{ matrix.cuda }}
+      PYVER: ${{ matrix.pyver }}
+
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.2.0
+        if: runner.os == 'Linux'
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.pyver }}
+        
+      - name: Setup Mamba
+        uses: conda-incubator/setup-miniconda@v2.2.0
+        with:
+          activate-environment: "build"
+          python-version: ${{ matrix.pyver }}
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          add-pip-as-python-dependency: true
+          auto-activate-base: false
+          
+      - name: Install Dependencies
+        run: |
+          $cudaVersion = $env:CUDAVER
+          $cudaVersionPytorch = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
+          
+          $cudaChannels = ''
+          $cudaNum = [int]$cudaVersion.substring($cudaVersion.LastIndexOf('.')+1)
+          while ($cudaNum -ge 0) { $cudaChannels += '-c nvidia/label/cuda-' + $cudaVersion.Remove($cudaVersion.LastIndexOf('.')+1) + $cudaNum + ' '; $cudaNum-- }
+          mamba install -y 'cuda' $cudaChannels.TrimEnd().Split()
+          
+          if ([version]$env:CUDAVER -gt [version]'11.8.0') {$torchver = "torch==2.1.0.* --pre --index-url https://download.pytorch.org/whl/nightly/cu$cudaVersionPytorch"} else {$torchver = "torch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch"}
+          python -m pip install $torchver.split()
+          
+          python -m pip install build wheel safetensors sentencepiece ninja
+        
+      - name: Build Wheel
+        id: build-wheel
+        run: |
+          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(') {Write-Output $('::notice file=build-wheels-release.yml,line=53,title=Package Version::Detected package version is: {0}' -f $Matches[1]); Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"} else {Write-Output '::error file=build-wheels-release.yml,line=41::Could not parse version from setup.py! You must upload wheels manually!'; Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"}
+          
+          $env:CUDA_PATH = $env:CONDA_PREFIX
+          $env:CUDA_HOME = $env:CONDA_PREFIX
+          
+          $cudaVersion = $env:CUDAVER
+          $cudaVersionPytorch = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
+          $BUILDTAG = "+cu$cudaVersionPytorch"
+          
+          if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
+          $env:TORCH_CUDA_ARCH_LIST = if ([version]$env:CUDAVER -lt [version]'11.8') {'6.0 6.1 7.0 7.5 8.0 8.6+PTX'} else {'6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX'}
+          python -m build -n --wheel -C--build-option=egg_info "-C--build-option=--tag-build=$BUILDTAG"
+          
+          if ($IsLinux -and $env:PYVER -eq '3.11' -and $env:CUDAVER -eq '11.8.0') {$env:EXLLAMA_NOCOMPILE=1; python -m build -n}
+        
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'wheels'
+          path: ./dist/*
+          
+      - name: Upload files to a GitHub release
+        if: steps.build-wheel.outputs.PACKAGE_VERSION != 'None'
+        uses: svenstaro/upload-release-action@2.6.1
+        with:
+          file: ./dist/*.whl
+          tag: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          file_glob: true
+          overwrite: true
+          release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+      
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: inputs.pypi == '1'
+    needs: ['build_wheels','build_rocm']
+    runs-on: ubuntu-latest
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/exllamav2
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      
+    steps:
+      - name: Download all the wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -86,8 +86,6 @@ jobs:
           if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
           $env:TORCH_CUDA_ARCH_LIST = if ([version]$env:CUDAVER -lt [version]'11.8') {'6.0 6.1 7.0 7.5 8.0 8.6+PTX'} else {'6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX'}
           python -m build -n --wheel -C--build-option=egg_info "-C--build-option=--tag-build=$BUILDTAG"
-          
-          if ($IsLinux -and $env:PYVER -eq '3.11' -and $env:CUDAVER -eq '11.8.0') {$env:EXLLAMA_NOCOMPILE=1; python -m build -n}
         
       - uses: actions/upload-artifact@v3
         with:
@@ -104,7 +102,7 @@ jobs:
           overwrite: true
           release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
       
-  publish-to-pypi:
+  publish-wheels-to-pypi:
     name: Publish Python distribution to PyPI
     if: inputs.pypi == '1'
     needs: ['build_wheels','build_rocm']
@@ -121,6 +119,67 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: wheels
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+        
+  build_sdist:
+    name: Build sdist
+    needs: publish-wheels-to-pypi
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+          
+      - name: Install Dependencies
+        run: |
+          python -m pip install build wheel ninja
+        
+      - name: Build Wheel
+        id: build-wheel-sdist
+        run: |
+          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(') {Write-Output $('::notice file=build-wheels-release.yml,line=53,title=Package Version::Detected package version is: {0}' -f $Matches[1]); Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"} else {Write-Output '::error file=build-wheels-release.yml,line=41::Could not parse version from setup.py! You must upload wheels manually!'; Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"}
+          $env:EXLLAMA_NOCOMPILE=1
+          python -m build
+        
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'sdist'
+          path: ./dist/*
+          
+      - name: Upload files to a GitHub release
+        if: steps.build-wheel-sdist.outputs.PACKAGE_VERSION != 'None'
+        uses: svenstaro/upload-release-action@2.6.1
+        with:
+          file: ./dist/*.whl
+          tag: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          file_glob: true
+          overwrite: true
+          release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+      
+  publish-sdist-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: inputs.pypi == '1'
+    needs: build_sdist
+    runs-on: ubuntu-latest
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/exllamav2
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      
+    steps:
+      - name: Download the sdist
+        uses: actions/download-artifact@v3
+        with:
+          name: sdist
           path: dist/
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/build-wheels-rocm.yml
+++ b/.github/workflows/build-wheels-rocm.yml
@@ -1,0 +1,60 @@
+name: Build ROCm 5.4.2 Wheels
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build_wheels:
+    name: Build ROCm wheel for Python ${{ matrix.pyver }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        pyver: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.2.0
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+    
+      - uses: actions/checkout@v3
+          
+      - name: Install ROCm SDK
+        run: |
+          export ROCM_VERSION=5.6
+          
+          [ ! -d /etc/apt/keyrings ] && sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+          wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ROCM_VERSION focal main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
+          echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+          sudo apt update
+          sudo apt install rocm-hip-sdk -y
+          echo "/opt/rocm/bin" >> $GITHUB_PATH
+          echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
+          echo "ROCM_VERSION=$ROCM_VERSION" >> $GITHUB_ENV
+          echo "USE_ROCM=1" >> $GITHUB_ENV
+          
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.pyver }}
+          
+      - name: Install Dependencies
+        run: |
+          pip3 install torch\<=2.1.0 --pre --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION" --extra-index-url="https://download.pytorch.org/whl/nightly/rocm$ROCM_VERSION"
+          pip3 install build wheel safetensors sentencepiece ninja
+        
+      - name: Build Wheel
+        run: |
+          BUILDTAG="+rocm$ROCM_VERSION"
+          python3 -m build -n --wheel -C--build-option=egg_info -C--build-option=--tag-build=$BUILDTAG
+        
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'wheels'
+          path: ./dist/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,82 @@
+name: Build Wheels
+
+on: workflow_dispatch
+
+jobs:
+  build_wheels:
+    name: ${{ matrix.os }} Python ${{ matrix.pyver }} CUDA ${{ matrix.cuda }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-latest]
+        pyver: ["3.8", "3.9", "3.10", "3.11"]
+        cuda: ["11.7.0", "11.8.0", "12.1.1"]
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CUDAVER: ${{ matrix.cuda }}
+      PYVER: ${{ matrix.pyver }}
+
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.2.0
+        if: runner.os == 'Linux'
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.pyver }}
+        
+      - name: Setup Mamba
+        uses: conda-incubator/setup-miniconda@v2.2.0
+        with:
+          activate-environment: "build"
+          python-version: ${{ matrix.pyver }}
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          add-pip-as-python-dependency: true
+          auto-activate-base: false
+          
+      - name: Install Dependencies
+        run: |
+          $cudaVersion = $env:CUDAVER
+          $cudaVersionPytorch = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
+          
+          $cudaChannels = ''
+          $cudaNum = [int]$cudaVersion.substring($cudaVersion.LastIndexOf('.')+1)
+          while ($cudaNum -ge 0) { $cudaChannels += '-c nvidia/label/cuda-' + $cudaVersion.Remove($cudaVersion.LastIndexOf('.')+1) + $cudaNum + ' '; $cudaNum-- }
+          mamba install -y 'cuda' $cudaChannels.TrimEnd().Split()
+          
+          if ([version]$env:CUDAVER -gt [version]'11.8.0') {$torchver = "torch==2.1.0.* --pre --index-url https://download.pytorch.org/whl/nightly/cu$cudaVersionPytorch"} else {$torchver = "torch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch"}
+          python -m pip install $torchver.split()
+          
+          python -m pip install build wheel safetensors sentencepiece ninja
+        
+      - name: Build Wheel
+        run: |
+          $env:CUDA_PATH = $env:CONDA_PREFIX
+          $env:CUDA_HOME = $env:CONDA_PREFIX
+          
+          $cudaVersion = $env:CUDAVER
+          $cudaVersionPytorch = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
+          $BUILDTAG = "+cu$cudaVersionPytorch"
+          
+          if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
+          $env:TORCH_CUDA_ARCH_LIST = if ([version]$env:CUDAVER -lt [version]'11.8') {'6.0 6.1 7.0 7.5 8.0 8.6+PTX'} else {'6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX'}
+          python -m build -n --wheel -C--build-option=egg_info "-C--build-option=--tag-build=$BUILDTAG"
+          
+          if ($IsLinux -and $env:PYVER -eq '3.11' -and $env:CUDAVER -eq '11.8.0') {$env:EXLLAMA_NOCOMPILE=1; python -m build -n}
+        
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'wheels'
+          path: ./dist/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -80,3 +80,8 @@ jobs:
         with:
           name: 'wheels'
           path: ./dist/*
+          
+  build_rocm:
+    name: Build ROCm Wheels & Release
+    needs: build_wheels
+    uses: ./.github/workflows/build-wheels-rocm.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info/
+build/

--- a/exllamav2/ext.py
+++ b/exllamav2/ext.py
@@ -10,121 +10,124 @@ ext_debug = False
 
 windows = (os.name == "nt")
 
-# Kludge to get compilation working on Windows
+try:
+    import exllamav2_ext
+except ModuleNotFoundError:
+    # Kludge to get compilation working on Windows
 
-if windows:
+    if windows:
 
-    def find_msvc():
+        def find_msvc():
 
-        # Possible locations for MSVC, in order of preference
+            # Possible locations for MSVC, in order of preference
 
-        program_files_x64 = os.environ["ProgramW6432"]
-        program_files_x86 = os.environ["ProgramFiles(x86)"]
+            program_files_x64 = os.environ["ProgramW6432"]
+            program_files_x86 = os.environ["ProgramFiles(x86)"]
 
-        msvc_dirs = \
-        [
-            a + "\\Microsoft Visual Studio\\" + b + "\\" + c + "\\VC\Tools\\MSVC\\"
-            for b in ["2022", "2019", "2017"]
-            for a in [program_files_x64, program_files_x86]
-            for c in ["BuildTools", "Community", "Professional", "Enterprise", "Preview"]
-        ]
+            msvc_dirs = \
+            [
+                a + "\\Microsoft Visual Studio\\" + b + "\\" + c + "\\VC\Tools\\MSVC\\"
+                for b in ["2022", "2019", "2017"]
+                for a in [program_files_x64, program_files_x86]
+                for c in ["BuildTools", "Community", "Professional", "Enterprise", "Preview"]
+            ]
 
-        for msvc_dir in msvc_dirs:
-            if not os.path.exists(msvc_dir): continue
+            for msvc_dir in msvc_dirs:
+                if not os.path.exists(msvc_dir): continue
 
-            # Prefer the latest version
+                # Prefer the latest version
 
-            versions = sorted(os.listdir(msvc_dir), reverse = True)
-            for version in versions:
+                versions = sorted(os.listdir(msvc_dir), reverse = True)
+                for version in versions:
 
-                compiler_dir = msvc_dir + version + "\\bin\\Hostx64\\x64"
-                if os.path.exists(compiler_dir) and os.path.exists(compiler_dir + "\\cl.exe"):
-                    return compiler_dir
+                    compiler_dir = msvc_dir + version + "\\bin\\Hostx64\\x64"
+                    if os.path.exists(compiler_dir) and os.path.exists(compiler_dir + "\\cl.exe"):
+                        return compiler_dir
 
-        # No path found
+            # No path found
 
-        return None
+            return None
 
-    import subprocess
+        import subprocess
 
-    # Check if cl.exe is already in the path
+        # Check if cl.exe is already in the path
 
-    try:
+        try:
 
-        subprocess.check_output(["where", "/Q", "cl"])
+            subprocess.check_output(["where", "/Q", "cl"])
 
-    # If not, try to find an installation of Visual Studio and append the compiler dir to the path
+        # If not, try to find an installation of Visual Studio and append the compiler dir to the path
 
-    except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError as e:
 
-        cl_path = find_msvc()
-        if cl_path:
-            if verbose:
-                print(" -- Injected compiler path:", cl_path)
-            os.environ["path"] += ";" + cl_path
-        else:
-            print(" !! Unable to find cl.exe; compilation will probably fail", file = sys.stderr)
-
-
-# gcc / cl.exe flags
-
-extra_cflags = ["/Ox"] if windows else ["-O3"]
-
-if ext_debug:
-    extra_cflags += ["-ftime-report", "-DTORCH_USE_CUDA_DSA"]
+            cl_path = find_msvc()
+            if cl_path:
+                if verbose:
+                    print(" -- Injected compiler path:", cl_path)
+                os.environ["path"] += ";" + cl_path
+            else:
+                print(" !! Unable to find cl.exe; compilation will probably fail", file = sys.stderr)
 
 
-# nvcc flags
+    # gcc / cl.exe flags
 
-extra_cuda_cflags = ["-lineinfo", "-O3"]
-# extra_cuda_cflags += ["-maxrregcount=128"]
+    extra_cflags = ["/Ox"] if windows else ["-O3"]
 
-
-# linker flags
-
-extra_ldflags = []
-
-if windows:
-    extra_ldflags += ["cublas.lib"]
-    if sys.base_prefix != sys.prefix:
-        extra_ldflags += [f"/LIBPATH:{os.path.join(sys.base_prefix, 'libs')}"]
+    if ext_debug:
+        extra_cflags += ["-ftime-report", "-DTORCH_USE_CUDA_DSA"]
 
 
-# sources
+    # nvcc flags
 
-library_dir = os.path.dirname(os.path.abspath(__file__))
-sources_dir = os.path.join(library_dir, extension_name)
-
-sources_ = \
-[
-    "ext.cpp",
-    "cuda/pack_tensor.cu",
-    "cuda/quantize.cu",
-    "cuda/q_matrix.cu",
-    "cuda/q_attn.cu",
-    "cuda/q_mlp.cu",
-    "cuda/q_gemm.cu",
-    "cuda/rms_norm.cu",
-    "cuda/rope.cu",
-    "cpp/quantize_func.cpp",
-    "cpp/sampling.cpp"
-]
-
-sources = [os.path.join(sources_dir, s) for s in sources_]
+    extra_cuda_cflags = ["-lineinfo", "-O3"]
+    # extra_cuda_cflags += ["-maxrregcount=128"]
 
 
-# Load extension
+    # linker flags
 
-exllamav2_ext = load \
-(
-    name = extension_name,
-    sources = sources,
-    extra_include_paths = [sources_dir],
-    verbose = verbose,
-    extra_ldflags = extra_ldflags,
-    extra_cuda_cflags = extra_cuda_cflags,
-    extra_cflags = extra_cflags
-)
+    extra_ldflags = []
+
+    if windows:
+        extra_ldflags += ["cublas.lib"]
+        if sys.base_prefix != sys.prefix:
+            extra_ldflags += [f"/LIBPATH:{os.path.join(sys.base_prefix, 'libs')}"]
+
+
+    # sources
+
+    library_dir = os.path.dirname(os.path.abspath(__file__))
+    sources_dir = os.path.join(library_dir, extension_name)
+
+    sources_ = \
+    [
+        "ext.cpp",
+        "cuda/pack_tensor.cu",
+        "cuda/quantize.cu",
+        "cuda/q_matrix.cu",
+        "cuda/q_attn.cu",
+        "cuda/q_mlp.cu",
+        "cuda/q_gemm.cu",
+        "cuda/rms_norm.cu",
+        "cuda/rope.cu",
+        "cpp/quantize_func.cpp",
+        "cpp/sampling.cpp"
+    ]
+
+    sources = [os.path.join(sources_dir, s) for s in sources_]
+
+
+    # Load extension
+
+    exllamav2_ext = load \
+    (
+        name = extension_name,
+        sources = sources,
+        extra_include_paths = [sources_dir],
+        verbose = verbose,
+        extra_ldflags = extra_ldflags,
+        extra_cuda_cflags = extra_cuda_cflags,
+        extra_cflags = extra_cflags
+    )
 
 ext_c = exllamav2_ext
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,47 @@
-from setuptools import setup
+from setuptools import setup, Extension
+from torch.utils import cpp_extension
+import os
+
+extension_name = "exllamav2_ext"
+verbose = False
+ext_debug = False
+
+precompile = 'EXLLAMA_NOCOMPILE' not in os.environ
+
+windows = (os.name == "nt")
+
+extra_cflags = ["/Ox"] if windows else ["-O3"]
+
+if ext_debug:
+    extra_cflags += ["-ftime-report", "-DTORCH_USE_CUDA_DSA"]
+
+extra_compile_args = {
+    "cxx": extra_cflags,
+    "nvcc": ["-lineinfo", "-O3"],
+}
+
+setup_kwargs = {
+    "ext_modules": [
+        cpp_extension.CUDAExtension(
+            extension_name,
+            [
+                "exllamav2/exllamav2_ext/ext.cpp",
+                "exllamav2/exllamav2_ext/cuda/pack_tensor.cu",
+                "exllamav2/exllamav2_ext/cuda/quantize.cu",
+                "exllamav2/exllamav2_ext/cuda/q_matrix.cu",
+                "exllamav2/exllamav2_ext/cuda/q_attn.cu",
+                "exllamav2/exllamav2_ext/cuda/q_mlp.cu",
+                "exllamav2/exllamav2_ext/cuda/q_gemm.cu",
+                "exllamav2/exllamav2_ext/cuda/rms_norm.cu",
+                "exllamav2/exllamav2_ext/cuda/rope.cu",
+                "exllamav2/exllamav2_ext/cpp/quantize_func.cpp",
+                "exllamav2/exllamav2_ext/cpp/sampling.cpp"
+            ],
+            extra_compile_args=extra_compile_args,
+            libraries=["cublas"] if windows else [],
+        )],
+    "cmdclass": {"build_ext": cpp_extension.BuildExtension}
+} if precompile else {}
 
 version = "0.0.3"
 
@@ -18,4 +61,6 @@ setup(
         "sentencepiece>=0.1.97",
     ],
     include_package_data = True,
+    verbose = verbose,
+    **setup_kwargs,
 )


### PR DESCRIPTION
Resolves: https://github.com/turboderp/exllamav2/issues/56

---
This makes JIT compiling optional and can be opted into by setting the `EXLLAMA_NOCOMPILE` environment variable on install.

This also includes 2 workflows:
- `build-wheels.yml`
  - This workflow will build wheels and sdist and upload them as workflow artifacts.
  - Useful for testing as you don't need to worry about overwriting working wheels with broken ones.
  - Calls `build-wheels-rocm.yml` to build ROCm wheels at the end.
- `build-wheels-release.yml`
  - This workflow will do the same as the first and will also upload them to GitHub releases that it will create if needed.
  - Parses `setup.py` to determine package version that it will then use as the release tag to upload to.
  - Currently configured to overwrite wheels already uploaded in a release.
  - Also uploads to PyPI. Current code for this is based on the info here:
  https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
  This may need to be adjusted as I have no experience working with PyPI and typically just make my own package indices.
  Regardless, an option is provided when running the workflow to not upload to PyPI.
  - Calls `build-wheels-release-rocm.yml` to build ROCm wheels just before building the sdist and JIT compile wheel.
- `build-wheels-rocm.yml`
  - This workflow will build wheels using ROCm 5.6. This version can be changed by editing the variable in the SDK installation step.
- `build-wheels-release-rocm.yml`
  - The same as the previous but also includes the upload functionality of `build-wheels-release.yml`.