### PR TITLE
Check if Ampere GPUs or newer before using flash-attn

### DIFF
--- a/exllamav2/attn.py
+++ b/exllamav2/attn.py
@@ -18,7 +18,9 @@ has_flash_attn = False
 try:
     import flash_attn
     flash_attn_ver = [int(t) for t in flash_attn.__version__.split(".") if t.isdigit()]
-    if flash_attn_ver >= [2, 2, 1]:
+    is_ampere_or_newer_gpu = any(torch.cuda.get_device_properties(i).major >= 8 for i in range(torch.cuda.device_count()))
+    
+    if flash_attn_ver >= [2, 2, 1] and is_ampere_or_newer_gpu:
         from flash_attn import flash_attn_func
         has_flash_attn = True
 except ModuleNotFoundError:


### PR DESCRIPTION
This should solve the error

```
File "/miniconda3/envs/textgen/lib/python3.10/site-packages/flash_attn/flash_attn_interface.py", line 47, in _flash_attn_forward
    out, q, k, v, out_padded, softmax_lse, S_dmask, rng_state = flash_attn_cuda.fwd(
RuntimeError: FlashAttention only supports Ampere GPUs or newer.
```

that happens while trying to generate text if you have flash-attn installed (through a wheel) but do not have a compatible GPU.