### PR TITLE
Use Pytorch 2.1 for CUDA 11.8+ and ROCm builds

### DIFF
--- a/.github/workflows/build-wheels-release-rocm.yml
+++ b/.github/workflows/build-wheels-release-rocm.yml
@@ -1,11 +1,11 @@
-name: Build ROCm 5.4.2 Wheels & Release
+name: Build ROCm 5.6 Wheels & Release
 
 on:
   workflow_dispatch:
     inputs:
       pypi:
         description: 'Upload wheels to PyPI? 1 = yes, 0 = no'
-        default: '1'
+        default: '0'
         required: true
         type: string
   workflow_call:
@@ -61,13 +61,21 @@ jobs:
           
       - name: Install Dependencies
         run: |
-          pip3 install torch==2.1.0.dev20230903 --pre --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION" --extra-index-url="https://download.pytorch.org/whl/nightly/rocm$ROCM_VERSION"
+          pip3 install torch==2.1.0 --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION"
           pip3 install build wheel safetensors sentencepiece ninja
         
       - name: Build Wheel
         id: build-wheel
         run: |
-          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(') {Write-Output $('::notice file=build-wheels-release-rocm.yml,line=54,title=Package Version::Detected package version is: {0}' -f $Matches[1]); Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"} else {Write-Output '::error file=build-wheels-release.yml,line=41::Could not parse version from setup.py! You must upload wheels manually!'; Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"}
+          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(')
+          {
+              Write-Output $('::notice file=build-wheels-release-rocm.yml,line=72,title=Package Version::Detected package version is: {0}' -f $Matches[1])
+              Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"
+          } else {
+              Write-Output '::error file=build-wheels-release.yml,line=75::Could not parse version from setup.py! You must upload wheels manually!'
+              Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"
+          }
+          
           $BUILDTAG = "+rocm$env:ROCM_VERSION"
           python3 -m build -n --wheel -C--build-option=egg_info "-C--build-option=--tag-build=$BUILDTAG"
         shell: pwsh

--- a/.github/workflows/build-wheels-release-rocm.yml
+++ b/.github/workflows/build-wheels-release-rocm.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip3 install torch==2.1.0 --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION"
-          pip3 install build wheel safetensors sentencepiece ninja
+          pip3 install --upgrade build setuptools wheel safetensors sentencepiece ninja
         
       - name: Build Wheel
         id: build-wheel

--- a/.github/workflows/build-wheels-release-rocm.yml
+++ b/.github/workflows/build-wheels-release-rocm.yml
@@ -2,12 +2,12 @@ name: Build ROCm 5.6 Wheels & Release
 
 on:
   workflow_dispatch:
-    inputs:
-      pypi:
-        description: 'Upload wheels to PyPI? 1 = yes, 0 = no'
-        default: '0'
-        required: true
-        type: string
+    # inputs:
+    #   pypi:
+    #     description: 'Upload wheels to PyPI? 1 = yes, 0 = no'
+    #     default: '0'
+    #     required: true
+    #     type: string
   workflow_call:
     inputs:
       pypi:
@@ -67,12 +67,13 @@ jobs:
       - name: Build Wheel
         id: build-wheel
         run: |
-          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(')
+          $versionString = Get-Content $(Join-Path 'exllamav2' 'version.py') -raw
+          if ($versionString -match '__version__ = "(\d+\.(?:\d+\.?(?:dev\d+)?)*)"')
           {
-              Write-Output $('::notice file=build-wheels-release-rocm.yml,line=72,title=Package Version::Detected package version is: {0}' -f $Matches[1])
+              Write-Output $('::notice file=build-wheels-release-rocm.yml,line=73,title=Package Version::Detected package version is: {0}' -f $Matches[1])
               Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"
           } else {
-              Write-Output '::error file=build-wheels-release.yml,line=75::Could not parse version from setup.py! You must upload wheels manually!'
+              Write-Output '::error file=build-wheels-release.yml,line=76::Could not parse version from exllamav2/version.py! You must upload wheels manually!'
               Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"
           }
           
@@ -90,28 +91,28 @@ jobs:
         uses: svenstaro/upload-release-action@2.6.1
         with:
           file: ./dist/*.whl
-          tag: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          tag: ${{ format('v{0}', steps.build-wheel.outputs.PACKAGE_VERSION) }}
           file_glob: true
           overwrite: true
           release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
       
-  publish-to-pypi:
-    name: Publish Python distribution to PyPI
-    if: inputs.pypi == '1' && github.event_name != 'workflow_call'
-    needs: ['build_wheels','build_rocm']
-    runs-on: ubuntu-latest
-    
-    environment:
-      name: pypi
-      url: https://pypi.org/p/exllamav2
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-      
-    steps:
-      - name: Download all the wheels
-        uses: actions/download-artifact@v3
-        with:
-          name: wheels
-          path: dist/
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+  # publish-to-pypi:
+  #   name: Publish Python distribution to PyPI
+  #   if: inputs.pypi == '1' && github.event_name != 'workflow_call'
+  #   needs: ['build_wheels']
+  #   runs-on: ubuntu-latest
+  #   
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/exllamav2
+  #   permissions:
+  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
+  #     
+  #   steps:
+  #     - name: Download all the wheels
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: wheels
+  #         path: dist/
+  #     - name: Publish distribution to PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -157,6 +157,7 @@ jobs:
           
       - name: Install Dependencies
         run: |
+          python -m pip install torch==2.0.1 --index-url https://download.pytorch.org/whl/cpu
           python -m pip install build wheel ninja
         
       - name: Build Wheel

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -162,7 +162,8 @@ jobs:
       - name: Build Wheel
         id: build-wheel-sdist
         run: |
-          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(')
+          $versionString = Get-Content $(Join-Path 'exllamav2' 'version.py') -raw
+          if ($versionString -match '__version__ = "(\d+\.(?:\d+\.?(?:dev\d+)?)*)"')
           {
               Write-Output $('::notice file=build-wheels-release.yml,line=166,title=Package Version::Detected package version is: {0}' -f $Matches[1])
               Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -174,7 +174,7 @@ jobs:
           }
           
           $env:EXLLAMA_NOCOMPILE=1
-          python -m build
+          python -m build -n
         
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -77,23 +77,24 @@ jobs:
       - name: Build Wheel
         id: build-wheel
         run: |
-          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(')
+          $versionString = Get-Content $(Join-Path 'exllamav2' 'version.py') -raw
+          if ($versionString -match '__version__ = "(\d+\.(?:\d+\.?(?:dev\d+)?)*)"')
           {
-              Write-Output $('::notice file=build-wheels-release.yml,line=82,title=Package Version::Detected package version is: {0}' -f $Matches[1])
+              Write-Output $('::notice file=build-wheels-release.yml,line=83,title=Package Version::Detected package version is: {0}' -f $Matches[1])
               Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"
           } else {
-              Write-Output '::error file=build-wheels-release.yml,line=85::Could not parse version from setup.py! You must upload wheels manually!'
+              Write-Output '::error file=build-wheels-release.yml,line=86::Could not parse version from exllamav2/version.py! You must upload wheels manually!'
               Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"
           }
           
           $env:CUDA_PATH = $env:CONDA_PREFIX
           $env:CUDA_HOME = $env:CONDA_PREFIX
+          if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
           
           $cudaVersion = $env:CUDAVER
           $cudaVersionPytorch = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
           $BUILDTAG = "+cu$cudaVersionPytorch"
           
-          if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
           $env:TORCH_CUDA_ARCH_LIST = if ([version]$env:CUDAVER -lt [version]'11.8') {'6.0 6.1 7.0 7.5 8.0 8.6+PTX'} else {'6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX'}
           python -m build -n --wheel -C--build-option=egg_info "-C--build-option=--tag-build=$BUILDTAG"
         
@@ -166,7 +167,7 @@ jobs:
               Write-Output $('::notice file=build-wheels-release.yml,line=166,title=Package Version::Detected package version is: {0}' -f $Matches[1])
               Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"
           } else {
-              Write-Output '::error file=build-wheels-release.yml,line=169::Could not parse version from setup.py! You must upload wheels manually!'
+              Write-Output '::error file=build-wheels-release.yml,line=169::Could not parse version from exllamav2/version.py! You must upload wheels manually!'
               Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"
           }
           

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -66,15 +66,25 @@ jobs:
           while ($cudaNum -ge 0) { $cudaChannels += '-c nvidia/label/cuda-' + $cudaVersion.Remove($cudaVersion.LastIndexOf('.')+1) + $cudaNum + ' '; $cudaNum-- }
           mamba install -y 'cuda' $cudaChannels.TrimEnd().Split()
           
-          if ([version]$env:CUDAVER -gt [version]'11.8.0') {$torchver = "torch==2.1.0.* --pre --index-url https://download.pytorch.org/whl/nightly/cu$cudaVersionPytorch"} else {$torchver = "torch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch"}
-          python -m pip install $torchver.split()
+          if (!(mamba list cuda)[-1].contains('cuda')) {sleep -s 10; mamba install -y 'cuda' $cudaChannels.TrimEnd().Split()}
+          if (!(mamba list cuda)[-1].contains('cuda')) {throw 'CUDA Toolkit failed to install!'}
+          
+          if ([version]$env:CUDAVER -lt [version]'11.8.0') {$torchver = "torch==2.0.1"} else {$torchver = "torch==2.1.0"}
+          python -m pip install $torchver --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch
           
           python -m pip install build wheel safetensors sentencepiece ninja
         
       - name: Build Wheel
         id: build-wheel
         run: |
-          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(') {Write-Output $('::notice file=build-wheels-release.yml,line=53,title=Package Version::Detected package version is: {0}' -f $Matches[1]); Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"} else {Write-Output '::error file=build-wheels-release.yml,line=41::Could not parse version from setup.py! You must upload wheels manually!'; Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"}
+          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(')
+          {
+              Write-Output $('::notice file=build-wheels-release.yml,line=82,title=Package Version::Detected package version is: {0}' -f $Matches[1])
+              Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"
+          } else {
+              Write-Output '::error file=build-wheels-release.yml,line=85::Could not parse version from setup.py! You must upload wheels manually!'
+              Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"
+          }
           
           $env:CUDA_PATH = $env:CONDA_PREFIX
           $env:CUDA_HOME = $env:CONDA_PREFIX
@@ -109,30 +119,30 @@ jobs:
     with:
       pypi: '0'
       
-  publish-wheels-to-pypi:
-    name: Publish Python distribution to PyPI
-    if: inputs.pypi == '1'
-    needs: ['build_wheels','build_rocm']
-    runs-on: ubuntu-latest
-    
-    environment:
-      name: pypi
-      url: https://pypi.org/p/exllamav2
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-      
-    steps:
-      - name: Download all the wheels
-        uses: actions/download-artifact@v3
-        with:
-          name: wheels
-          path: dist/
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+  # publish-wheels-to-pypi:
+  #   name: Publish Python distribution to PyPI
+  #   if: inputs.pypi == '1'
+  #   needs: ['build_wheels','build_rocm']
+  #   runs-on: ubuntu-latest
+  #   
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/exllamav2
+  #   permissions:
+  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
+  #     
+  #   steps:
+  #     - name: Download all the wheels
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: wheels
+  #         path: dist/
+  #     - name: Publish distribution to PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.8.10
         
   build_sdist:
     name: Build sdist
-    needs: publish-wheels-to-pypi
+    needs: ['build_wheels','build_rocm'] # publish-wheels-to-pypi
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -151,14 +161,22 @@ jobs:
       - name: Build Wheel
         id: build-wheel-sdist
         run: |
-          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(') {Write-Output $('::notice file=build-wheels-release.yml,line=53,title=Package Version::Detected package version is: {0}' -f $Matches[1]); Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"} else {Write-Output '::error file=build-wheels-release.yml,line=41::Could not parse version from setup.py! You must upload wheels manually!'; Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"}
+          if ($(Get-Content 'setup.py' -raw) -match 'version = "(\d+\.(?:\d+\.?)*)" \+ \(')
+          {
+              Write-Output $('::notice file=build-wheels-release.yml,line=166,title=Package Version::Detected package version is: {0}' -f $Matches[1])
+              Write-Output "PACKAGE_VERSION=$($Matches[1])" >> "$env:GITHUB_OUTPUT"
+          } else {
+              Write-Output '::error file=build-wheels-release.yml,line=169::Could not parse version from setup.py! You must upload wheels manually!'
+              Write-Output "PACKAGE_VERSION=None" >> "$env:GITHUB_OUTPUT"
+          }
+          
           $env:EXLLAMA_NOCOMPILE=1
           python -m build
         
       - uses: actions/upload-artifact@v3
         with:
           name: 'sdist'
-          path: ./dist/*
+          path: ./dist/* # Use ./dist/*.whl to only upload the JIT compile wheel
           
       - name: Upload files to a GitHub release
         if: steps.build-wheel-sdist.outputs.PACKAGE_VERSION != 'None'

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -108,7 +108,7 @@ jobs:
         uses: svenstaro/upload-release-action@2.6.1
         with:
           file: ./dist/*.whl
-          tag: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          tag: ${{ format('v{0}', steps.build-wheel.outputs.PACKAGE_VERSION) }}
           file_glob: true
           overwrite: true
           release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
@@ -185,7 +185,7 @@ jobs:
         uses: svenstaro/upload-release-action@2.6.1
         with:
           file: ./dist/*.whl
-          tag: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          tag: ${{ format('v{0}', steps.build-wheel.outputs.PACKAGE_VERSION) }}
           file_glob: true
           overwrite: true
           release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}

--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -186,10 +186,10 @@ jobs:
         uses: svenstaro/upload-release-action@2.6.1
         with:
           file: ./dist/*.whl
-          tag: ${{ format('v{0}', steps.build-wheel.outputs.PACKAGE_VERSION) }}
+          tag: ${{ format('v{0}', steps.build-wheel-sdist.outputs.PACKAGE_VERSION) }}
           file_glob: true
           overwrite: true
-          release_name: ${{ steps.build-wheel.outputs.PACKAGE_VERSION }}
+          release_name: ${{ steps.build-wheel-sdist.outputs.PACKAGE_VERSION }}
       
   publish-sdist-to-pypi:
     name: Publish Python distribution to PyPI

--- a/.github/workflows/build-wheels-rocm.yml
+++ b/.github/workflows/build-wheels-rocm.yml
@@ -1,4 +1,4 @@
-name: Build ROCm 5.4.2 Wheels
+name: Build ROCm 5.6 Wheels
 
 on:
   workflow_dispatch:
@@ -46,7 +46,7 @@ jobs:
           
       - name: Install Dependencies
         run: |
-          pip3 install torch==2.1.0.dev20230903 --pre --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION" --extra-index-url="https://download.pytorch.org/whl/nightly/rocm$ROCM_VERSION"
+          pip3 install torch==2.1.0 --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION"
           pip3 install build wheel safetensors sentencepiece ninja
         
       - name: Build Wheel

--- a/.github/workflows/build-wheels-rocm.yml
+++ b/.github/workflows/build-wheels-rocm.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip3 install torch==2.1.0 --index-url="https://download.pytorch.org/whl/rocm$ROCM_VERSION"
-          pip3 install build wheel safetensors sentencepiece ninja
+          pip3 install --upgrade build setuptools wheel safetensors sentencepiece ninja
         
       - name: Build Wheel
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -56,8 +56,11 @@ jobs:
           while ($cudaNum -ge 0) { $cudaChannels += '-c nvidia/label/cuda-' + $cudaVersion.Remove($cudaVersion.LastIndexOf('.')+1) + $cudaNum + ' '; $cudaNum-- }
           mamba install -y 'cuda' $cudaChannels.TrimEnd().Split()
           
-          if ([version]$env:CUDAVER -gt [version]'11.8.0') {$torchver = "torch==2.1.0.* --pre --index-url https://download.pytorch.org/whl/nightly/cu$cudaVersionPytorch"} else {$torchver = "torch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch"}
-          python -m pip install $torchver.split()
+          if (!(mamba list cuda)[-1].contains('cuda')) {sleep -s 10; mamba install -y 'cuda' $cudaChannels.TrimEnd().Split()}
+          if (!(mamba list cuda)[-1].contains('cuda')) {throw 'CUDA Toolkit failed to install!'}
+          
+          if ([version]$env:CUDAVER -lt [version]'11.8.0') {$torchver = "torch==2.0.1"} else {$torchver = "torch==2.1.0"}
+          python -m pip install $torchver --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch
           
           python -m pip install build wheel safetensors sentencepiece ninja
         


### PR DESCRIPTION
For most systems, the wheels built on Pytorch 2.0.1 work fine with 2.1.
However, for unknown reasons, some systems seem to not work at all unless the wheel is built with Pytorch 2.1.

This PR changes the workflows to use the official Pytorch 2.1 release with CUDA 11.8+ and ROCm.
It also adds some basic error correction as I noticed that Mamba will not always report an error and stop the workflow if CUDA Toolkit fails to install.

I also commented out the PyPI upload functionality for non-sdist builds for convenience as it can't be used at the moment.
Should now only try to upload the JIT-compile wheel and the sdist itself.
I added a comment on line 179 detailing how to only upload the wheel and can add that change to this PR if you want.

Additionally, I made the following changes to the Powershell code that reads the package version number in the release workflows:
- Made the code more readable
- Now uses the `exllamav2/version.py` file for detection
- Now uses the release tag format of: `v{version_number}`

To clarify, it's purpose is to determine the package version number for uploading the wheels to a release using that version number.
It prevents automatic uploading to a release and will notify you in the event that the version number is not detected for some reason.