### PR TITLE
Load models' tokenizer.json file with utf-8 encoding.

### DIFF
--- a/exllamav2/tokenizer.py
+++ b/exllamav2/tokenizer.py
@@ -73,7 +73,7 @@ class ExLlamaV2Tokenizer:
 
         tokenizer_json_path = os.path.join(self.config.model_dir, "tokenizer.json")
         if os.path.exists(tokenizer_json_path):
-            with open(tokenizer_json_path) as f:
+            with open(tokenizer_json_path, encoding="utf-8") as f:
                 tokenizer_json = json.load(f)
                 if "added_tokens" in tokenizer_json:
                     for v in tokenizer_json["added_tokens"]:


### PR DESCRIPTION
Otherwise, `json` sometimes fails to parse the contents e.g.

```
  File "E:\exllamav2_ui\exllamav2\model_init.py", line 101, in init
    tokenizer = ExLlamaV2Tokenizer(config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\exllamav2_ui\exllamav2\tokenizer.py", line 77, in __init__
    tokenizer_json = json.load(f)
                     ^^^^^^^^^^^^
  File "C:\Program Files\Python311\Lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
                 ^^^^^^^^^
UnicodeDecodeError: 'cp932' codec can't decode byte 0x81 in position 812: illegal multibyte sequence
```

Not sure if this could be necessary anywhere else, didn't have any other files fail to load.