### PR TITLE
Added draft model rope scale to chat example

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -106,6 +106,7 @@ if args.draft_model_dir:
 
     draft_config.max_seq_len = model.config.max_seq_len
     draft_config.no_flash_attn = args.no_flash_attn
+    draft_config.scale_pos_emb = args.rope_scale
 
     print(" -- Loading draft model...")
 


### PR DESCRIPTION
When setting a custom rope scale, now the `chat.py` example also sets the same rope scale for the draft model (needed for deepseek drafting)