### PR TITLE
feat: add top-A sampling

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -38,6 +38,7 @@ parser.add_argument("-sp", "--system_prompt", type = str, help = "Use custom sys
 parser.add_argument("-temp", "--temperature", type = float, default = 0.95, help = "Sampler temperature, default = 0.95 (1 to disable)")
 parser.add_argument("-topk", "--top_k", type = int, default = 50, help = "Sampler top-K, default = 50 (0 to disable)")
 parser.add_argument("-topp", "--top_p", type = float, default = 0.8, help = "Sampler top-P, default = 0.8 (0 to disable)")
+parser.add_argument("-topa", "--top_a", type = float, default = 0.0, help = "Sampler top-A, default = 0.0 (0 to disable)")
 parser.add_argument("-typical", "--typical", type = float, default = 0.0, help = "Sampler typical threshold, default = 0.0 (0 to disable)")
 parser.add_argument("-repp", "--repetition_penalty", type = float, default = 1.05, help = "Sampler repetition penalty, default = 1.05 (1 to disable)")
 parser.add_argument("-maxr", "--max_response_tokens", type = int, default = 1000, help = "Max tokens per response, default = 1000")
@@ -187,6 +188,7 @@ settings = ExLlamaV2Sampler.Settings()
 settings.temperature = args.temperature
 settings.top_k = args.top_k
 settings.top_p = args.top_p
+settings.top_a = args.top_a
 settings.typical = args.typical
 settings.token_repetition_penalty = args.repetition_penalty
 

--- a/examples/inference.py
+++ b/examples/inference.py
@@ -42,6 +42,7 @@ settings = ExLlamaV2Sampler.Settings()
 settings.temperature = 0.85
 settings.top_k = 50
 settings.top_p = 0.8
+settings.top_a = 0.0
 settings.token_repetition_penalty = 1.05
 settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 

--- a/examples/lora.py
+++ b/examples/lora.py
@@ -52,6 +52,7 @@ settings = ExLlamaV2Sampler.Settings()
 settings.temperature = 0.85
 settings.top_k = 50
 settings.top_p = 0.8
+settings.top_a = 0.0
 settings.token_repetition_penalty = 1.1
 
 # Alpaca-style prompt

--- a/examples/speculative.py
+++ b/examples/speculative.py
@@ -100,6 +100,7 @@ gen_settings = ExLlamaV2Sampler.Settings()
 gen_settings.temperature = 0.6
 gen_settings.top_k = 50
 gen_settings.top_p = 0.6
+gen_settings.top_a = 0.0
 gen_settings.token_repetition_penalty = 1.0
 gen_settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -42,6 +42,7 @@ settings = ExLlamaV2Sampler.Settings()
 settings.temperature = 0.85
 settings.top_k = 50
 settings.top_p = 0.8
+settings.top_a = 0.0
 settings.token_repetition_penalty = 1.05
 settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 

--- a/exllamav2/exllamav2_ext/cpp/sampling.cpp
+++ b/exllamav2/exllamav2_ext/cpp/sampling.cpp
@@ -1,5 +1,6 @@
 #include "sampling.h"
 #include "util.h"
+#include "algorithm"
 #include <math.h>
 #include <vector>
 #include <queue>

--- a/exllamav2/exllamav2_ext/cpp/sampling.cpp
+++ b/exllamav2/exllamav2_ext/cpp/sampling.cpp
@@ -458,8 +458,10 @@ int top_a_cpu
     float top_a
 )
 {
-    // Find the maximum probability
+    // Sort the probabilities and indices
     float top_prob = temp_probs[0];
+    for (int i = 1; i < num_candidates; i++)
+        if (temp_probs[i] > top_prob) top_prob = temp_probs[i];
 
     // Calculate the threshold
     float threshold = top_a * top_prob * top_prob;

--- a/exllamav2/exllamav2_ext/cpp/sampling.cpp
+++ b/exllamav2/exllamav2_ext/cpp/sampling.cpp
@@ -459,10 +459,10 @@ int top_a_cpu
 )
 {
     // Find the maximum probability
-    float max_prob = *std::max_element(temp_probs, temp_probs + num_candidates);
+    float top_prob = temp_probs[0];
 
     // Calculate the threshold
-    float threshold = top_a * max_prob * max_prob;
+    float threshold = top_a * top_prob * top_prob;
 
     // Use the keep_threshold function to keep only probabilities above the threshold
     int n = keep_threshold(num_candidates, temp_probs, temp_indices, threshold);

--- a/exllamav2/exllamav2_ext/cpp/sampling.cpp
+++ b/exllamav2/exllamav2_ext/cpp/sampling.cpp
@@ -1,6 +1,5 @@
 #include "sampling.h"
 #include "util.h"
-#include "algorithm"
 #include <math.h>
 #include <vector>
 #include <queue>

--- a/exllamav2/exllamav2_ext/cpp/sampling.cpp
+++ b/exllamav2/exllamav2_ext/cpp/sampling.cpp
@@ -458,7 +458,7 @@ int top_a_cpu
     float top_a
 )
 {
-    // Sort the probabilities and indices
+    // Find top probability
     float top_prob = temp_probs[0];
     for (int i = 1; i < num_candidates; i++)
         if (temp_probs[i] > top_prob) top_prob = temp_probs[i];

--- a/exllamav2/exllamav2_ext/cpp/sampling.cpp
+++ b/exllamav2/exllamav2_ext/cpp/sampling.cpp
@@ -1,5 +1,6 @@
 #include "sampling.h"
 #include "util.h"
+#include "algorithm"
 #include <math.h>
 #include <vector>
 #include <queue>
@@ -447,6 +448,26 @@ int keep_threshold
         j--;
     }
     return i;
+}
+
+int top_a_cpu
+(
+    const int num_candidates,
+    float* temp_probs,
+    int* temp_indices,
+    float top_a
+)
+{
+    // Find the maximum probability
+    float max_prob = *std::max_element(temp_probs, temp_probs + num_candidates);
+
+    // Calculate the threshold
+    float threshold = top_a * max_prob * max_prob;
+
+    // Use the keep_threshold function to keep only probabilities above the threshold
+    int n = keep_threshold(num_candidates, temp_probs, temp_indices, threshold);
+
+    return n;
 }
 
 int min_p_cpu

--- a/exllamav2/exllamav2_ext/cpp/sampling.h
+++ b/exllamav2/exllamav2_ext/cpp/sampling.h
@@ -63,6 +63,14 @@ int top_p_cpu
     float top_p
 );
 
+int top_a_cpu
+(
+    const int num_candidates,
+    float* temp_probs,
+    int* temp_indices,
+    int top_a
+);
+
 int min_p_cpu
 (
     const int num_candidates,

--- a/exllamav2/exllamav2_ext/cpp/sampling.h
+++ b/exllamav2/exllamav2_ext/cpp/sampling.h
@@ -68,7 +68,7 @@ int top_a_cpu
     const int num_candidates,
     float* temp_probs,
     int* temp_indices,
-    int top_a
+    float top_a
 );
 
 int min_p_cpu

--- a/exllamav2/exllamav2_ext/ext.cpp
+++ b/exllamav2/exllamav2_ext/ext.cpp
@@ -851,6 +851,7 @@ std::vector<float> sample_basic
     float temperature,
     int top_k,
     float top_p,
+    float top_a,
     float min_p,
     float tfs,
     float typical,
@@ -923,6 +924,12 @@ std::vector<float> sample_basic
         if (top_p > 0.0f && top_p < 1.0f)
         {
             num_candidates = top_p_cpu(num_candidates, temp_probs, temp_indices, top_p);
+            normalize_cpu(num_candidates, temp_probs);
+        }
+
+        if (top_a > 0.0f)
+        {
+            num_candidates = top_a_cpu(num_candidates, temp_probs, temp_indices, top_a);
             normalize_cpu(num_candidates, temp_probs);
         }
 

--- a/exllamav2/generator/sampler.py
+++ b/exllamav2/generator/sampler.py
@@ -14,6 +14,7 @@ class ExLlamaV2Sampler:
         temperature = 0.8
         top_k = 50
         top_p = 0.8
+        top_a = 0.0
         min_p = 0
         tfs = 0
         typical = 0
@@ -41,6 +42,7 @@ class ExLlamaV2Sampler:
             c.temperature = self.temperature
             c.top_k = self.top_k
             c.top_p = self.top_p
+            c.top_a = self.top_a
             c.min_p = self.min_p
             c.tfs = self.tfs
             c.typical = self.typical

--- a/exllamav2/generator/sampler.py
+++ b/exllamav2/generator/sampler.py
@@ -170,6 +170,7 @@ class ExLlamaV2Sampler:
                                1.0 if settings.temperature_last else settings.temperature,
                                settings.top_k,
                                settings.top_p,
+                               settings.top_a,
                                settings.min_p,
                                settings.tfs,
                                settings.typical,

--- a/exllamav2/server/websocket_actions.py
+++ b/exllamav2/server/websocket_actions.py
@@ -104,6 +104,7 @@ async def infer(request, ws, server, response):
                 stream_full: bool,                  # return full response-so-far with each streamed chunk
                 top_p: float,                       # (optional) top-P threshold (0 to disable)
                 top_k: int,                         # (optional) top-K count (0 to disable)
+                top_a: float,                       # (optional) top-A threshold (0 to disable)
                 min_p: float,                       # (optional) min-P threshold (0 to disable)
                 typical: float,                     # (optional) typical threshold (0 to disable)
                 temperature: float,                 # (optional) sampling temperature (1.0 = no temp adjust)
@@ -169,6 +170,7 @@ async def infer(request, ws, server, response):
     gs = ExLlamaV2Sampler.Settings()
     gs.top_k = int(request["top_k"]) if "top_k" in request else 100
     gs.top_p = float(request["top_p"]) if "top_p" in request else 0.8
+    gs.top_a = float(request["top_a"]) if "top_a" in request else 0
     gs.min_p = float(request["min_p"]) if "min_p" in request else 0
     gs.typical = float(request["typical"]) if "typical" in request else 0
     gs.temperature = float(request["temperature"]) if "temperature" in request else 0.9

--- a/tests/test.py
+++ b/tests/test.py
@@ -74,6 +74,7 @@ def test_gen_normal(prompt, max_new_tokens):
     settings.temperature = 0.85
     settings.top_k = 50
     settings.top_p = 0.8
+    settings.top_a = 0.0
     settings.token_repetition_penalty = 1.15
     settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 
@@ -103,6 +104,7 @@ def test_gen_streaming(prompt, max_new_tokens):
     settings.temperature = 0.85
     settings.top_k = 50
     settings.top_p = 0.8
+    settings.top_a = 0.0
     settings.token_repetition_penalty = 1.15
     settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 
@@ -150,6 +152,7 @@ def test_gen_batch(max_new_tokens):
     settings.temperature = 0.85
     settings.top_k = 50
     settings.top_p = 0.8
+    settings.top_a = 0.0
     settings.token_repetition_penalty = 1.15
     settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 
@@ -183,6 +186,7 @@ def test_multicache(max_new_tokens):
     settings.temperature = 0.85
     settings.top_k = 50
     settings.top_p = 0.8
+    settings.top_a = 0.0
     settings.token_repetition_penalty = 1.15
     settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
 


### PR DESCRIPTION
This PR adds support for Top-A sampling (invented by BlinkDL from the RWKV team). Based on the min_p implementation here, since min_p is just linear top_a.