### PR TITLE
Loras: Remove qkv assertion

### DIFF
--- a/exllamav2/lora.py
+++ b/exllamav2/lora.py
@@ -44,10 +44,6 @@ class ExLlamaV2Lora:
             self.bias_ignored = False
             self.lora_scaling = lora_scaling
 
-            # Check for QKV embed
-
-            assert not self.model.config.qkv_embed, "LoRAs not implemented for models loaded with QKV embeddings"
-
             # Grab relevant items from LoRA config
 
             with open(lora_config_path, encoding = "utf8") as f:


### PR DESCRIPTION
QKV embeddings no longer exist in config, so this assertion will always fire due to config having QKV as None.