### PR TITLE
Fix case where there are no disallowed tokens in `websocket_actions.py`

### DIFF
--- a/exllamav2/server/websocket_actions.py
+++ b/exllamav2/server/websocket_actions.py
@@ -179,7 +179,8 @@ async def infer(request, ws, server, response):
     gs.token_repetition_penalty = float(request["rep_pen"]) if "rep_pen" in request else 1.05
     gs.token_frequency_penalty = float(request["freq_pen"]) if "freq_pen" in request else 0.0
     gs.token_presence_penalty = float(request["pres_pen"]) if "pres_pen" in request else 0.0
-    gs.disallow_tokens(server.tokenizer, bb)
+    if bb is not None:
+        gs.disallow_tokens(server.tokenizer, bb)
 
     # Generate
 


### PR DESCRIPTION
I might be misunderstanding something here, but [this code](https://github.com/turboderp/exllamav2/blob/3b0f5230e9619fc0ddf1f302785049d10a65fe26/exllamav2/server/websocket_actions.py#L152) in `websocket_actions.py`:

```python
    if "bann_bann" in request:
        bb = request["bann_bann"]
        if not isinstance(bb, list): bb = [bb]
    else:
        bb = None
```
Combined with this code that follows:
```python
    gs = ExLlamaV2Sampler.Settings()
    # ...
    gs.disallow_tokens(server.tokenizer, bb)
```
Means that we may be passing `None` to `disallow_tokens`, which looks like [this](https://github.com/turboderp/exllamav2/blob/3b0f5230e9619fc0ddf1f302785049d10a65fe26/exllamav2/generator/sampler.py#L83C9-L83C9):
```py
        def disallow_tokens(self, tokenizer, tokens):

            if self.token_bias is None:
                padding = -tokenizer.config.vocab_size % 32
                self.token_bias = torch.zeros((tokenizer.config.vocab_size + padding,), dtype = torch.float)

            self.token_bias[tokens] = float("-inf")
```
And that causes all values in `self.token_bias` to be set to `-inf` (I don't know Python/Pytorch well enough to know why that is).

Please close this if there's a more appropriate change/refactor to fix this, assuming it is actually a bug. Of if you'd just rather do it on your machine since it's such a simple change. I guess you might also want to add a check in `disallow_tokens` to catch future bugs like this.

Thanks!