### PR TITLE
Repeat layers to create FrankenModels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .idea
 venv
 dist
+*.so


### PR DESCRIPTION
## Description
This slightly modifies the forward pass, to reuse layers to allow the creation and use of 'Frankenmodels' quickly and easily.

The format of the new argument is:
`python test_inference.py  -m /models/lzlv_70b_fp16_hf-4.0bpw-h6-exl2 -p "Once upon a time:" -gs 18,18 --repeats '[(0,20),(10,30),(20,40),(30,50),(40,60),(50,70),(60,79)]'`

This would generate the [nsfwthrowitaway69/Venus-120b-v1.2
](https://huggingface.co/nsfwthrowitaway69/Venus-120b-v1.2/blob/main/mergekit_config.yml) Frankenmodels, while reducing VRAM usage by 50b params.

The repeats parameter is a string list of tuples. As the final layers in most models are model.norm and lm_head (not a number), the last value in the last tuple should be one lower than the final layer number. So long as this is the case, the code will extend out the layer so all are included. i.e. `[(0,20),(10,28)] and  [(0,20),(10,30)]` would generate the same Frankenmodel.


## Related Discussion
discussion at #270 and a discussion on Reddit [localllama](https://www.reddit.com/r/LocalLLaMA/comments/190zsk1/comment/kgu7ffj/) about the potential of easily creating Frankenstein models using exllama.

## Explanation of changes
A new parameter was added to argparse, and in ExLlamaV2.__init__ if the param was used, we build a list of the layer order to use including repeats.  In the ExLlamaV2._forward method, the actual model forward pass is extracted into a private process_module method, and this is called in the usual way with looping through self.modules if 'repeats' is not passed, and looping through self.layers_list if it is passed.