### PR TITLE
Add graceful exit sig handling and status box for quantization to assist estimating completion time and overall accuracy

### DIFF
--- a/conversion/measure.py
+++ b/conversion/measure.py
@@ -19,6 +19,28 @@ import os, time, math, json
 import torch.nn.functional as F
 import gc
 
+# graceful exiting
+import signal
+import sys
+
+interrupted = False
+
+def signal_handler(signal, frame):
+    global interrupted
+    if interrupted:
+        print("\nGracefully exiting...")
+        sys.exit(0)
+    else:
+        interrupted = True
+        print("\nCTRL-C again to quit or type 'exit'. You can always resume the process at a later time.")
+        user_input = input("\nPress Enter to continue processing or type 'exit' to quit: ").strip().lower()
+        if user_input == 'exit':
+            print("Gracefully exiting...")
+            sys.exit(0)
+        interrupted = False
+
+signal.signal(signal.SIGINT, signal_handler)
+
 def list_live_tensors():
 
     tensors = {}
@@ -268,9 +290,34 @@ def measure_moe_mlp(module, hidden_states, target_states, quantizers, cache, att
 
     return results
 
+# helpful status box for insights around conversions
+def get_remaining_time_str(estimated_time_remaining):
+    remaining_minutes = int(estimated_time_remaining // 60)
+    remaining_seconds = int(estimated_time_remaining % 60)
+    return f"{remaining_minutes}min {remaining_seconds}sec"
+
+def format_line(label, box_width):
+    return f"| {label.ljust(box_width - 3)}|"
+
+def print_status_box(*content_lines):
+    max_content_width = max(len(line) for line in content_lines)
+    box_width = max_content_width + 4 
+
+    print('-' * box_width)
+    for line in content_lines:
+        print(format_line(line, box_width))
+    print('-' * box_width)
 
 @torch.inference_mode()
 def measure_quant(job, save_fn, model):
+
+    # vars for status box
+    time_spent_list = []  
+    rolling_window_size = 10 # (increase to average over larger window)
+    completed_steps = 0  
+    accuracy_sum = 0  
+    accuracy_count = 0  
+    overall_rolling_accuracy = 0  
 
     snapshot_interval = 10
     temp_filename = os.path.join(job["out_dir"], "hidden_states_temp.safetensors")
@@ -282,6 +329,11 @@ def measure_quant(job, save_fn, model):
     if not "last_module_idx" in job:
         job["last_module_idx"] = 0
 
+    # vars to support status box
+    total_modules = len(model.modules)  
+    last_module_idx = job["last_module_idx"]  # resume tracking steps where it stopped previously
+    remaining_steps = total_modules - last_module_idx  
+
     hidden_states = []
     with safe_open(states_filename, framework = "pt", device = "cpu") as f:
         for k in sorted(f.keys()):
@@ -289,6 +341,18 @@ def measure_quant(job, save_fn, model):
 
     index = job["last_module_idx"]
     while True:
+
+        # sig handler should catch it faster in most cases
+        if interrupted:
+            print("Measurement process was interrupted. Please decide:")
+            if interrupted:
+                print("Exiting after saving the current state.")
+                job["measurement"] = measurement.copy()
+                job["last_module_idx"] = index
+                save_fn()
+                return "interrupted"
+            else:
+                print("Resuming the process.")
 
         index += 1
         if index >= len(model.modules): break
@@ -394,6 +458,16 @@ def measure_quant(job, save_fn, model):
 
         measurement[module.key + "." + mode] = m
 
+        # track overall accuracy for status box
+        if m is not None and len(m) > 0:
+            layer_accuracies = [result['accuracy'] for result in m]
+            layer_accuracy_sum = sum(layer_accuracies)
+            layer_accuracy_count = len(layer_accuracies)
+            
+            accuracy_sum += layer_accuracy_sum
+            accuracy_count += layer_accuracy_count
+            overall_rolling_accuracy = accuracy_sum / accuracy_count 
+
         # Unload module
 
         module.unload()
@@ -403,11 +477,33 @@ def measure_quant(job, save_fn, model):
 
         hidden_states = target_states
 
-        # Timing
+        # Timing and status box
 
         end_time = time.time()
         duration = end_time - begin_time
-        print(f" -- Duration: {duration:.2f} seconds")
+
+        time_spent_list.append(duration)
+        if len(time_spent_list) > rolling_window_size:
+            time_spent_list.pop(0)
+        average_time_per_step = sum(time_spent_list) / len(time_spent_list)
+
+        remaining_steps = total_modules - index
+        estimated_total_time = average_time_per_step * remaining_steps
+        estimated_time_remaining = max(estimated_total_time - sum(time_spent_list), 0)
+        completed_steps = index
+
+        completed_module_name_str = f"Completed: {module.key} ({module.name})"
+        duration_str = f"Duration: {duration:.2f} seconds"
+        completed_step_str = f"Completed step: {completed_steps}/{total_modules}"
+        avg_time_str = f"Avg time / step (rolling): {average_time_per_step:.2f} seconds"
+        remaining_time_str = f"Estimated remaining time: {get_remaining_time_str(estimated_time_remaining)}"
+        overall_accuracy_str = f"Overall avg accuracy: {overall_rolling_accuracy:.8f}" if accuracy_count > 0 else ""
+
+        content_lines = [completed_module_name_str, duration_str, completed_step_str, avg_time_str, remaining_time_str]
+        if accuracy_count > 0:
+            content_lines.append(overall_accuracy_str)
+
+        print_status_box(*content_lines)
 
         # Checkpoint
 
@@ -443,4 +539,4 @@ def measure_quant(job, save_fn, model):
         with open(filename, "w", encoding = "utf8") as f:
             f.write(json.dumps(exp_measurement, indent = 4))
 
-
+    return "completed"  # graceful exiting 

--- a/conversion/quantize.py
+++ b/conversion/quantize.py
@@ -422,11 +422,9 @@ def quant(job, save_fn, model):
             save_fn()
 
             if mode != "linear":
-                os.remove(states_filename)
-                os.rename(temp_filename, states_filename)
+                os.replace(temp_filename, states_filename)
 
             job["q_last_module_idx"] = index
 
             del job["invalid"]
             save_fn()
-

--- a/convert.py
+++ b/convert.py
@@ -215,9 +215,12 @@ while True:
         save_job()
 
     if progress == "measure_quant":
-
         print(f" -- Measuring quantization impact...")
-        measure_quant(job, save_job, model)
+        status = measure_quant(job, save_job, model)  # capturing the graceful exits
+        if status == "interrupted":
+            print("Process interrupted. Exiting gracefully.")
+            save_job()
+            sys.exit(1)  
         if job["output_measurement"] is None:
             job["progress"] = "optimize"
         else:


### PR DESCRIPTION
A few user experience enhancements during the quantization and measurement process:

1. Graceful Exit Signal Handling:
   - Adds signal handling to allow the measurement process of quantization to exit gracefully. This ensures that the process can be safely paused or stopped, and provides a catch / second chance if a user hits CTRL-C unintentionally.

2. Status Box with useful insights:
   - Implements a status box that appears after each measurement process completes of a module in the step-process that provides valuable insights during the quantization process. Most useful is probably the overall accuracy of the quantization and measurement process at that precise moment in time, and a time estimate for completion of the full quant.
   
Stats in the status box include:
     - Rolling average time per step. 
     - Estimated time for completion of the full process. (Uses rolling avg with a default window of last 10 modules) 
     - Step tracking (current step out of total steps). This also has a graceful resume that attempts to find which step it is on on out of the total layers remaining out of steps completed so far.
     - Overall average accuracy of all measurements taken during the quantization process.

The idea here is simply to improve the user experience by providing better control and visibility during the quantization process. For those paying for compute to quantize, the time to completion estimates can assist with calculating compute costs.


https://github.com/turboderp/exllamav2/assets/5460972/a010f4f2-f575-49b7-8297-df3c75b9cf33

