### PR TITLE
Resolved compiler Warnings for typecasting for proper byte reading and comparison

### DIFF
--- a/exllamav2/exllamav2_ext/cpp/safetensors.cpp
+++ b/exllamav2/exllamav2_ext/cpp/safetensors.cpp
@@ -90,7 +90,7 @@ STPage* get_cache_page(size_t file_descriptor, size_t block_size, size_t filesiz
 
     for (int i = 0; i < MAX_PAGES; i++)
     {
-        if (pages[i].file_descriptor == file_descriptor &&
+        if (static_cast<size_t>(pages[i].file_descriptor) == file_descriptor &&
             pages[i].file_a == file_a &&
             pages[i].file_b == file_b)
         {
@@ -195,7 +195,8 @@ STPage* get_cache_page(size_t file_descriptor, size_t block_size, size_t filesiz
         DBGX2(bytes_read, read_lens[i]);
         #endif
 
-        TORCH_CHECK(bytes_read == read_lens[i], "Async read error (2)");
+        TORCH_CHECK(bytes_read == static_cast<ssize_t>(read_lens[i]), "Async read error (2)");
+
     }
 
     return &pages[p];
@@ -292,7 +293,10 @@ void STFile::load
     // Get cache pages
 
     size_t file_b = offset / PAGESIZE * PAGESIZE;
+ 
+   /* doest appear to be utilized rn 
     size_t file_c = DIVIDE(offset + length, PAGESIZE) * PAGESIZE;
+   */
 
     // Loop over pages
 


### PR DESCRIPTION
Resolved specific compiler warnings in safetensors.cpp related to type mismatch and unused variables.

Type Mismatch in Comparisons: Ensured consistent typing by using static_cast to match the signedness of integers during comparisons to resolve warnings for:

Comparison between int and size_t in get_cache_page function.

Comparison between ssize_t and size_t in the check TORCH_CHECK(bytes_read == read_lens[i], "Async read error (2)");.

Unused Variables: Commented out the unused variable file_c in the STFile::load function to eliminate the -Wunused-variable warning.

Rebuilt everything after, warnings gone, inference and functionality seem to work per the usual.