### PR TITLE
Fix a couple of filter bugs

### DIFF
--- a/exllamav2/generator/base.py
+++ b/exllamav2/generator/base.py
@@ -105,9 +105,8 @@ class ExLlamaV2BaseGenerator:
         for i in range(num_tokens):
 
             logits = self.model.forward(self.sequence_ids[:, -1:], self.cache, input_mask = mask, loras = loras, position_offsets = position_offsets).float().cpu()
-            token, _, _, _, _ = ExLlamaV2Sampler.sample(logits, gen_settings, self.sequence_ids, random.random(), self.tokenizer, prefix_token = unhealed_token)
+            token, _, _, _, eos = ExLlamaV2Sampler.sample(logits, gen_settings, self.sequence_ids, random.random(), self.tokenizer, prefix_token = unhealed_token)
 
-            eos = False
             if stop_token is not None:
                 for b in range(batch_size):
                     if token[b, 0].item() == stop_token:

--- a/exllamav2/generator/filters/select.py
+++ b/exllamav2/generator/filters/select.py
@@ -27,7 +27,7 @@ class ExLlamaV2SelectFilter(ExLlamaV2Filter):
 
         self.sequence_str = ""
         self.sequence_str_cmp = ""
-        self.prefix = prefix_str
+        self.prefix = prefix_str if prefix_str is not None else ""
         self.offset = 0
 
 


### PR DESCRIPTION
Ran into two bugs trying to use the `Select` filter:

1. The sampler passes "None" as the prefix argument to `begin` when there's no healed token. This was causing an exception because Select expects the prefix to be a string.
2. The generator was ignoring the `end_filter` return value from the sampler, causing it to keep generating even after matching an end token from the `Select` filter. The result is that the Select filter returns an empty `pass_tokens` set on the next call to `next`, causing an exception.

This fixes the first by setting the prefix to the empty string if it's None, and the second by using the `end_filter` return value from the sampler as the default value for the `eos` variable in the generator, which tells the generator it's hit the eos token.

Only tested with `Select` and `generate_simple`. The `Prefix` filter never sets end tokens, so the main thing that might break is `lm-format-enforcer` if it's using `end_tokens` incorrectly.