### PR TITLE
Build on Ubuntu 20.04 for releases

### DIFF
--- a/.github/workflows/build-wheels-release.yml
+++ b/.github/workflows/build-wheels-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         pyver: ["3.8", "3.9", "3.10", "3.11"]
         cuda: ["11.7.0", "11.8.0", "12.1.1"]
     defaults:


### PR DESCRIPTION
I haven't actually tested this (I think I would need credentials), but the other workflows are running on Ubuntu 20.04 so I think it'll work.

 See #338 for details. 20.04 should be compatible with 22.04 and any newer distributions for a good while.

Docs on GitHub runners: https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#choosing-github-hosted-runners