### PR TITLE
Concurrency: Add opportunities to abort on processing

### DIFF
--- a/exllamav2/model.py
+++ b/exllamav2/model.py
@@ -1,5 +1,5 @@
 
-import os, sys
+import os, sys, threading
 min_version = (3, 8)
 if sys.version_info < min_version:
     print("")
@@ -513,7 +513,8 @@ class ExLlamaV2:
                 last_id_only = False,
                 loras = None,
                 return_last_state = False,
-                position_offsets = None):
+                position_offsets = None,
+                abort_event: threading.Event = None):
 
         q_len = input_ids.shape[-1]
         remaining_q_len = q_len
@@ -557,6 +558,10 @@ class ExLlamaV2:
 
         chunk_begin = 0
         while chunk_begin < q_len:
+            # Abort if the signal is set
+
+            if abort_event and abort_event.is_set():
+                break
 
             # Limit chunk_size to max_input_len
 


### PR DESCRIPTION
Use threading events to propagate an abort handler from prompt processing to the model forward function. Doing this allows for termination of the while loop which is extremely useful in concurrent programs that use exl2 and allows for scaling of larger context sizes.

NOTE: This PR is only a **proof of concept**, it's currently passing an abort handler through multiple functions which is not ideal (and doesn't even work with draft models). I propose putting the handler in the Model class along with resetting the handler every time forward is initially called (since that's the common denominator). However, I'm not sure what other issues this will bring especially with running multiple generations in parallel.

Documentation regarding stopping running tasks with threading [SuperFastPython - Stop Running Tasks Using threading.Event](https://superfastpython.com/threadpoolexecutor-stop-tasks/#Stop_Running_Tasks_Using_threadingEvent)