### PR TITLE
Fix installation step (install requirements) & Add multi-GPU explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ then run:
 ```
 git clone https://github.com/turboderp/exllamav2
 cd exllamav2
+# Optionally, create and activate a new conda environment
+pip install -r requirements.txt
 pip install .
 
 python test_inference.py -m <path_to_model> -p "Once upon a time,"
+# Append the '--gpu_split auto' flag for multi-GPU inference
 ```
 
 A simple console chatbot is included. Run it with:
 
 ```
 python examples/chat.py -m <path_to_model> -mode llama
+# Append the '--gpu_split auto' flag for multi-GPU inference
 ```
 
 
@@ -79,6 +83,7 @@ To install the current dev version, clone the repo and run the setup script:
 ```
 git clone https://github.com/turboderp/exllamav2
 cd exllamav2
+pip install -r requirements.txt
 pip install .
 ```
 

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -25,11 +25,11 @@ from chat_prompts import prompt_formats
 prompt_formats_list = list(prompt_formats.keys())
 
 # Options
+# (!!!) NOTE: These go on top of the engine arguments that can be found in `model_init.py` (!!!)
 
 parser = argparse.ArgumentParser(description = "Simple Llama2 chat example for ExLlamaV2")
 parser.add_argument("-dm", "--draft_model_dir", type = str, default = None, help = "Path to draft model directory")
 parser.add_argument("-nds", "--no_draft_scale", action = "store_true", help = "If draft model has smaller context size than model, don't apply alpha (NTK) scaling to extend it")
-parser.add_argument("-gs", "--gpu_split", type = str, help = "Split the model between multiple GPUs. Use `--gpu_split auto` for automatic handling or `--gpu_split x,y` to manually assign the VRAM on each device")
 
 parser.add_argument("-modes", "--modes", action = "store_true", help = "List available modes and exit.")
 parser.add_argument("-mode", "--mode", choices = prompt_formats_list, help = "Chat mode. Use llama for Llama 1/2 chat finetunes.")

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -29,6 +29,7 @@ prompt_formats_list = list(prompt_formats.keys())
 parser = argparse.ArgumentParser(description = "Simple Llama2 chat example for ExLlamaV2")
 parser.add_argument("-dm", "--draft_model_dir", type = str, default = None, help = "Path to draft model directory")
 parser.add_argument("-nds", "--no_draft_scale", action = "store_true", help = "If draft model has smaller context size than model, don't apply alpha (NTK) scaling to extend it")
+parser.add_argument("-gs", "--gpu_split", type = str, help = "Split the model between multiple GPUs. Use `--gpu_split auto` for automatic handling or `--gpu_split x,y` to manually assign the VRAM on each device")
 
 parser.add_argument("-modes", "--modes", action = "store_true", help = "List available modes and exit.")
 parser.add_argument("-mode", "--mode", choices = prompt_formats_list, help = "Chat mode. Use llama for Llama 1/2 chat finetunes.")

--- a/test_inference.py
+++ b/test_inference.py
@@ -54,6 +54,7 @@ parser.add_argument("-nwu", "--no_warmup", action = "store_true", help = "Skip w
 parser.add_argument("-sl", "--stream_layers", action = "store_true", help = "Load model layer by layer (perplexity evaluation only)")
 parser.add_argument("-sp", "--standard_perplexity", choices = ["wiki2"], help = "Run standard (HF) perplexity test, stride 512 (experimental)")
 parser.add_argument("-rr", "--rank_reduce", type = str, help = "Rank-reduction for MLP layers of model, in reverse order (for experimentation)")
+parser.add_argument("-gs", "--gpu_split", type = str, help = "Split the model between multiple GPUs. Use `--gpu_split auto` for automatic handling or `--gpu_split x,y` to manually assign the VRAM on each device")
 
 # Initialize model and tokenizer
 

--- a/test_inference.py
+++ b/test_inference.py
@@ -36,6 +36,7 @@ torch.set_printoptions(precision = 10)
 # torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = True
 # torch.set_float32_matmul_precision("medium")
 
+# (!!!) NOTE: These go on top of the engine arguments that can be found in `model_init.py` (!!!)
 parser = argparse.ArgumentParser(description = "Test inference on ExLlamaV2 model")
 parser.add_argument("-ed", "--eval_dataset", type = str, help = "Perplexity evaluation dataset (.parquet file)")
 parser.add_argument("-er", "--eval_rows", type = int, default = 128, help = "Number of rows to apply from dataset")
@@ -54,7 +55,6 @@ parser.add_argument("-nwu", "--no_warmup", action = "store_true", help = "Skip w
 parser.add_argument("-sl", "--stream_layers", action = "store_true", help = "Load model layer by layer (perplexity evaluation only)")
 parser.add_argument("-sp", "--standard_perplexity", choices = ["wiki2"], help = "Run standard (HF) perplexity test, stride 512 (experimental)")
 parser.add_argument("-rr", "--rank_reduce", type = str, help = "Rank-reduction for MLP layers of model, in reverse order (for experimentation)")
-parser.add_argument("-gs", "--gpu_split", type = str, help = "Split the model between multiple GPUs. Use `--gpu_split auto` for automatic handling or `--gpu_split x,y` to manually assign the VRAM on each device")
 
 # Initialize model and tokenizer
 


### PR DESCRIPTION
There was a missing `pip install -r requirements.txt` step on the installation steps on main page.
This PR adds it with some additional comments/reminders about conda environment (not necessary but potentially useful).

In addition, added some info for people that want to load models on multiple-GPUs.