### PR TITLE
Simple quarot proof of concept.

### DIFF
--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -93,6 +93,7 @@ class ExLlamaV2Config:
 
     checkpoint_fused_mlp: bool
 
+    quarot: bool = False
 
     def __init__(self,
                  model_dir: str | None = None):
@@ -200,6 +201,10 @@ class ExLlamaV2Config:
                                                   "model_max_length",
                                                   "max_position_embeddings",
                                                   "max_seq_len"], 2048)
+        
+        quarot_config = read(read_config, dict, "quarot_config", None)
+        if quarot_config is not None:
+            self.quarot = quarot_config["rotated"]
 
         rs = read(read_config, dict, "rope_scaling", None)
         if rs and "factor" in rs:

--- a/exllamav2/model.py
+++ b/exllamav2/model.py
@@ -169,9 +169,9 @@ class ExLlamaV2:
                 pd = ExLlamaV2ParallelDecoder(self, layer_key, layer_idx)
                 self.modules += [pd]
             else:
-                attn = ExLlamaV2Attention(self, layer_key, layer_idx)
+                attn = ExLlamaV2Attention(self, layer_key, layer_idx, quarot=self.config.quarot)
                 if self.config.arch.is_moe: mlp = ExLlamaV2MoEMLP(self, layer_key, layer_idx)
-                else: mlp = ExLlamaV2MLP(self, layer_key, layer_idx)
+                else: mlp = ExLlamaV2MLP(self, layer_key, layer_idx, quarot=self.config.quarot)
                 self.modules += [attn, mlp]
 
         if self.config.arch.norm == "layernorm": norm = ExLlamaV2LayerNorm(self, "model.norm")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ websockets
 regex
 numpy
 tokenizers
+git+https://github.com/sgsdxzy/AutoQuarot.git


### PR DESCRIPTION
How to enable QuaRot for weight quantization:

1. install AutoQuarot `pip install git+https://github.com/sgsdxzy/AutoQuarot.git`
2. convert the fp16 model to quarot weights
```
import transformers
import auto_quarot

model = transformers.AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16)
qrmodel = auto_quarot.AutoQuarotForForCausalLM.from_transformers(model)
qrmodel.fuse_layer_norms()
qrmodel.rotate_model("hadamard", device=0)
qrmodel.model.save_pretrained(rotated_model_path)
```
3. use exllamav2 to quantize/run the rotated model, it will be recognized automatically.