### PR TITLE
Load generation_config.json from compatible models

### DIFF
--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -161,10 +161,12 @@ class ExLlamaV2Config:
                 self.generation_config = {}
                 try:
                     self.generation_config['eos_token_id'] = read(gen_config, list, "eos_token_id", None)
-                except ValueError as e:
+                except (ValueError, TypeError):
                     eos_token_id_as_int = read(gen_config, int, "eos_token_id", None)
-                    if eos_token_id_as_int:
+                    if eos_token_id_as_int is not None:
                         self.generation_config['eos_token_id'] = [eos_token_id_as_int]
+                    else:
+                        self.generation_config['eos_token_id'] = None
                     
         
         # Model architecture

--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -152,6 +152,15 @@ class ExLlamaV2Config:
         with open(self.model_config, encoding = "utf8") as f:
             read_config = json.load(f)
 
+        # Load generation_config.json
+
+        self.generation_config_path = os.path.join(self.model_dir, "generation_config.json")
+        if os.path.exists(self.generation_config_path):
+            with open(self.generation_config_path, encoding = "utf8") as f:
+                gen_config = json.load(f)
+                self.generation_config = {}
+                self.generation_config['eos_token_id'] = read(gen_config, list, "eos_token_id", None)
+        
         # Model architecture
 
         assert len(read_config["architectures"]) == 1, "Multiple architectures defined in config.json"

--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -159,7 +159,13 @@ class ExLlamaV2Config:
             with open(self.generation_config_path, encoding = "utf8") as f:
                 gen_config = json.load(f)
                 self.generation_config = {}
-                self.generation_config['eos_token_id'] = read(gen_config, list, "eos_token_id", None)
+                try:
+                    self.generation_config['eos_token_id'] = read(gen_config, list, "eos_token_id", None)
+                except ValueError as e:
+                    eos_token_id_as_int = read(gen_config, int, "eos_token_id", None)
+                    if eos_token_id_as_int:
+                        self.generation_config['eos_token_id'] = [eos_token_id_as_int]
+                    
         
         # Model architecture
 


### PR DESCRIPTION
This update provides a convenient way to grab `generator_config` properties from `ExLlamaV2Config`, specifically the `eos_token_id` attribute.

Llama-3-instruct models provide `generator_config.json` which contains `eos_token_id` as a list of token IDs accounting for `<|end_of_text|>` and `<|eot_id|>` as stop tokens. The `tokenizer.eos_token_id` typically contains just the end of sequence token and not end of chat token. Llama-3 `generator_config.json` started incorporating both token ids into its config to make adding stop tokens easier.

https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/blob/main/generation_config.json