### PR TITLE
integrate xformers

### DIFF
--- a/examples/cfg.py
+++ b/examples/cfg.py
@@ -13,6 +13,7 @@ config = ExLlamaV2Config()
 config.model_dir = model_directory
 config.max_batch_size = 2
 config.no_flash_attn = True
+config.no_xformers = True
 config.prepare()
 
 model = ExLlamaV2(config)

--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -56,6 +56,7 @@ class ExLlamaV2Config:
     scale_alpha_value: float                    # Alpha value for NTK RoPE scaling. Similar to compress_pos_emb but works without finetuned model
 
     no_flash_attn: bool                         # Implementation will automatically use flash-attn-2 when available
+    no_xformers: bool                           # Implementation will automatically use xformers for sm<80 when available
     fasttensors: bool                           # Experimental, Linux only
     load_in_q4: bool                            # Load float linear layers in Q4 format (for test/dev purposes, not performant)
 
@@ -117,6 +118,7 @@ class ExLlamaV2Config:
         self.alt_rope_method = None
 
         self.no_flash_attn = False
+        self.no_xformers= False
         self.fasttensors = False
         self.load_in_q4 = False
 

--- a/exllamav2/model.py
+++ b/exllamav2/model.py
@@ -29,7 +29,7 @@ from exllamav2.linear import ExLlamaV2Linear
 from exllamav2.module import ExLlamaV2Module
 from exllamav2.rmsnorm import ExLlamaV2RMSNorm
 from exllamav2.layernorm import ExLlamaV2LayerNorm
-from exllamav2.attn import ExLlamaV2Attention, has_flash_attn
+from exllamav2.attn import ExLlamaV2Attention, has_flash_attn, has_xformers
 from exllamav2.lora import ExLlamaV2Lora
 from exllamav2.mlp import ExLlamaV2MLP
 from exllamav2.moe_mlp import ExLlamaV2MoEMLP
@@ -720,7 +720,7 @@ class ExLlamaV2:
 
             # Limit chunk_size to keep size of attention operation <= max_attention_size
 
-            if has_flash_attn:
+            if has_flash_attn or has_xformers:
 
                 # Can't measure increase in VRAM usage with longer k_len, assume usage is constant
                 # for given chunk_size

--- a/exllamav2/model_init.py
+++ b/exllamav2/model_init.py
@@ -15,6 +15,7 @@ def add_args(parser):
     parser.add_argument("-rs", "--rope_scale", type = float, help = "RoPE scaling factor")
     parser.add_argument("-ra", "--rope_alpha", type = float, help = "RoPE alpha value (NTK)")
     parser.add_argument("-nfa", "--no_flash_attn", action = "store_true", help = "Disable Flash Attention")
+    parser.add_argument("-nxf", "--no_xformers", action = "store_true", help = "Disable xformers, an alternative plan of flash attn for older devices")
     parser.add_argument("-lm", "--low_mem", action = "store_true", help = "Enable VRAM optimizations, potentially trading off speed")
     parser.add_argument("-ept", "--experts_per_token", type = int, help = "Override MoE model's default number of experts per token")
     parser.add_argument("-lq4", "--load_q4", action = "store_true", help = "Load weights in Q4 mode")


### PR DESCRIPTION
integrate xformers memory_efficient_attention, could be beneficial if your device's architecture is less than <sm_80
The efficiency between xformers.memory_efficient_attention and flash_attn in >sm_80 are almost the same. 
But xformer does not expand the kv automatically, we need to do it manually, and the martix operation make this implemention much slower. 

So the open logic is, try using flash_attn first and then try using xformer and then using Torch matmul attention.

