### PR TITLE
optimization: reduce GPU transfers

### DIFF
--- a/conversion/measure.py
+++ b/conversion/measure.py
@@ -165,7 +165,7 @@ def batch_test_error(module_factory, factory_params, hidden_states, target_state
     ]
 
 
-def measure_attn(module, hidden_states, target_states, quantizers, cache, attn_params, keep_q = False):
+def measure_attn(module, hidden_states, target_states, quantizers, cache, attn_params, keep_q = False, param_cache_size = 10000):
 
     qjobs, qmaps = get_qparams_reduced(qparams_attn)
     results = []
@@ -185,7 +185,7 @@ def measure_attn(module, hidden_states, target_states, quantizers, cache, attn_p
     total_numel += module.v_proj.numel()
     total_numel += module.o_proj.numel()
 
-    pcache = ParamCache({'q': options_q, 'k': options_k, 'v': options_v, 'o': options_o})
+    pcache = ParamCache({'q': options_q, 'k': options_k, 'v': options_v, 'o': options_o}, maxsize = param_cache_size)
 
     def module_factory(qkvo):
         q, k, v, o = qkvo
@@ -410,7 +410,7 @@ def print_status_box(*content_lines):
     print('-' * box_width)
 
 @torch.inference_mode()
-def measure_quant(job, save_fn, model):
+def measure_quant(job, save_fn, model, param_cache_size):
 
     # vars for status box
     time_spent_list = []  
@@ -592,7 +592,7 @@ def measure_quant(job, save_fn, model):
         m = None
 
         if mode == "self_attn":
-            m = measure_attn(module, hidden_states, target_states, quantizers, cache, attn_params)
+            m = measure_attn(module, hidden_states, target_states, quantizers, cache, attn_params, param_cache_size=param_cache_size)
 
         if mode == "mlp":
             m = measure_mlp(module, hidden_states, target_states, quantizers, cache, attn_params)

--- a/conversion/measure.py
+++ b/conversion/measure.py
@@ -125,7 +125,7 @@ def test_quant(source: ExLlamaV2Linear,
 
 def test_error(module, hidden_states, target_states, cache, attn_params):
 
-    rfn_sum = 0
+    rfn_sum = torch.tensor(0.0).cuda()
     rfn_count = 0
     for x, xref in zip(hidden_states, target_states):
         x = x.cuda()
@@ -133,10 +133,10 @@ def test_error(module, hidden_states, target_states, cache, attn_params):
         xtest = module.forward(x, cache, attn_params)
         xtest = xtest[0].float()
         xref = xref[0].float()
-        rfn_sum += (torch.linalg.norm(xtest - xref, 'fro') / torch.linalg.norm(xref, 'fro')).item()
+        rfn_sum += torch.linalg.norm(xtest - xref, 'fro') / torch.linalg.norm(xref, 'fro')
         rfn_count += 1
 
-    return max(1e-6, 1 - (rfn_sum / rfn_count))
+    return max(1e-6, 1 - (rfn_sum.item() / rfn_count))
 
 
 def batch_test_error(module_factory, factory_params, hidden_states, target_states, cache, attn_params):

--- a/conversion/measure.py
+++ b/conversion/measure.py
@@ -21,6 +21,7 @@ import os, time, math, json
 import torch.nn.functional as F
 import gc
 from conversion.bot_status import print_stage
+from tqdm import tqdm
 
 # graceful exiting
 import signal
@@ -144,14 +145,13 @@ def batch_test_error(module_factory, factory_params, hidden_states, target_state
     rfn_sums = [torch.tensor(0.0).cuda() for _ in factory_params]
     rfn_count = 0
     print(f" -- Testing {len(hidden_states)} samples with {len(factory_params)} variants")
-    for x, xref in zip(hidden_states, target_states):
+    for x, xref in tqdm(zip(hidden_states, target_states), total=len(hidden_states)):
         torch.cuda.empty_cache()
 
         x = x.cuda()
         xref = xref.cuda()
         xref = xref[0].float()
 
-        print(f" -- Sample {rfn_count + 1}/{len(hidden_states)}")
         for i, params in enumerate(factory_params):
             xtest = module_factory(params).forward(x, cache, attn_params)
             xtest = xtest[0].float()

--- a/conversion/quantize.py
+++ b/conversion/quantize.py
@@ -439,7 +439,7 @@ def quant(job, save_fn, model):
                 cal_ids = f.get_tensor("input_ids")
             module.linear.weight.data = module.linear.weight.data.to("cuda:0")
 
-        rfn_sum = 0
+        rfn_sum = torch.tensor(0.0).cuda()
         rfn_count = 0
         logprob_sum = 0.0
         logprob_count = 0
@@ -458,7 +458,7 @@ def quant(job, save_fn, model):
                 output_ref = target_states[i].to("cuda:0")
                 output_ref = output_ref[0].float()
 
-                rfn_sum += (torch.linalg.norm(output - output_ref, 'fro') / torch.linalg.norm(output_ref, 'fro')).item()
+                rfn_sum += torch.linalg.norm(output - output_ref, 'fro') / torch.linalg.norm(output_ref, 'fro')
                 rfn_count += 1
 
                 output_ref = None
@@ -485,7 +485,7 @@ def quant(job, save_fn, model):
 
         if mode != "linear":
 
-            err = rfn_sum / rfn_count
+            err = rfn_sum.item() / rfn_count
             print(f" -- Module quantized, rfn_error: {err:1.6f}")
 
         else:

--- a/convert.py
+++ b/convert.py
@@ -29,6 +29,7 @@ parser.add_argument("-mr", "--measurement_rows", type = int, default = 16, help 
 parser.add_argument("-l", "--length", type = int, default = 2048, help = "Max no. tokens per sample")
 parser.add_argument("-ml", "--measurement_length", type = int, default = 2048, help = "Max no. tokens per sample when measuring")
 parser.add_argument("-so", "--status_output", action = "store_true", help = "Include machine-parseable status updates in console output")
+parser.add_argument("-pcs", "--param_cache_size", type = int, default = 10000, help = "Parameter cache size in MB (lower to reduce VRAM use with speed penalty)")
 
 args = parser.parse_args()
 
@@ -242,7 +243,7 @@ while True:
         model = ExLlamaV2(config)
         model.load(lazy = True)
 
-        status = measure_quant(job, save_job, model)  # capturing the graceful exits
+        status = measure_quant(job, save_job, model, args.param_cache_size)  # capturing the graceful exits
         if status == "interrupted":
             print("Process interrupted. Exiting gracefully.")
             save_job()


### PR DESCRIPTION
This PR adds a `ParamCache` to the qparams file, which manages a cache of `nn.Parameter(option[idx].weight.cuda())` elements.

It also adds a new `batch_test_error` function which takes a model factory and factory parameters, and processes each layer in turn, for all model variations, i.e. the opposite of what is happening already.

This gives a 30% increase in speed for the attention layer, at a cost of some additional VRAM usage.

However, applying this method to the `measure_mlp` function does not give significant speed-ups, so the VRAM bump is not worth it. I'm still investigating why this is the case.

Supercedes (incorporates) #455.

This PR primarily targets the calibration feature, but the .item() tweak to test_error snuck its way into the quantize part. Can remove. Do intend to address quantization optimizations.

```
==================================================================

                               attn

==================================================================

BASE MASTER:

VRAM PEAK = 2715 MB

--------------------------------------------
| Measured: model.layers.0 (Attention)     |
| Duration: 96.49 seconds                  |
| Completed step: 1/163                    |
| Avg time / step (rolling): 96.49 seconds |
| Estimated remaining time: 260min 31sec   |
| Last checkpoint layer: None              |
--------------------------------------------

------------------------------------------------------------------

MASTER + PARAMCACHE + BATCHING

VRAM PEAK = 6200 MB

--------------------------------------------
| Measured: model.layers.0 (Attention)     |
| Duration: 60.14 seconds                  |
| Completed step: 1/163                    |
| Avg time / step (rolling): 60.14 seconds |
| Estimated remaining time: 162min 23sec   |
| Last checkpoint layer: None              |
--------------------------------------------
```