### PR TITLE
Remove stray ) in code example

### DIFF
--- a/doc/dynamic.md
+++ b/doc/dynamic.md
@@ -178,7 +178,7 @@ single completion:
 output = generator.generate(
     prompt = "Five good reasons to adopt a cat:",
     max_new_tokens = 200,
-    add_bos = True)
+    add_bos = True,
 )
 
 print(output)


### PR DESCRIPTION
This makes the example work.

I have no idea why github added an edit to the last line with the cat, since I didn't touch that line. I can't even see the edit it made.