### PR TITLE
Fix async job cancellation

### DIFF
--- a/exllamav2/generator/dynamic_async.py
+++ b/exllamav2/generator/dynamic_async.py
@@ -75,6 +75,7 @@ class ExLlamaV2DynamicJobAsync:
     job: ExLlamaV2DynamicJob
     queue: asyncio.Queue
     generator: ExLlamaV2DynamicGeneratorAsync
+    cancelled: bool = False
 
     def __init__(self, generator: ExLlamaV2DynamicGeneratorAsync, *args: object, **kwargs: object):
         self.generator = generator
@@ -87,6 +88,10 @@ class ExLlamaV2DynamicJobAsync:
 
     async def __aiter__(self):
         while True:
+            # Get out if the job is cancelled
+            if self.cancelled:
+                break
+
             result = await self.queue.get()
             if isinstance(result, Exception):
                 raise result
@@ -96,3 +101,4 @@ class ExLlamaV2DynamicJobAsync:
 
     async def cancel(self):
         await self.generator.cancel(self)
+        self.cancelled = True


### PR DESCRIPTION
If an async job is cancelled, tell the job to stop generating instead of waiting forever.

~~I'm not sure if the cancel event should raise something, but I put it as a simple break like how an EOS would work. Maybe this should be changed.~~

The correct way to terminate an iterator is to break it. This is done with `__anext__` via `StopAsyncIteration`, but that's not used for this generator.