### PR TITLE
Adding stream to 1 kernel.

### DIFF
--- a/exllamav2/exllamav2_ext/cuda/q_gemm.cu
+++ b/exllamav2/exllamav2_ext/cuda/q_gemm.cu
@@ -104,7 +104,8 @@ void gemm_half_q_half_cuda_part
 
         // Launch kernel
 
-        kernel<<<gridDim, blockDim>>>
+        const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+        kernel<<<gridDim, blockDim, 0, stream>>>
         (
             a,
             b->cuda_q_weight,
@@ -165,7 +166,8 @@ void gemm_half_q_half_cuda_part
 //             print_global_mem(r_weights, 1, 1, 1);
 //         DBGI(r_weights_stride);
 
-        kernel<<<gridDim, blockDim>>>
+        const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+        kernel<<<gridDim, blockDim, 0, stream>>>
         (
             a,
             b->cuda_q_weight,

--- a/exllamav2/exllamav2_ext/cuda/q_mlp.cu
+++ b/exllamav2/exllamav2_ext/cuda/q_mlp.cu
@@ -105,7 +105,8 @@ void QMLP::forward_
         apply_loras_cuda(cublas_handle, up_proj_lora,   loras, up,   norm_state, temp_b, lora_temp, rows);
 
         fp_act_mul_kernel kernel = pick_act_mul_kernel(use_half2, false, act_gelu);
-        kernel<<<gridDim, blockDim>>>(temp_a, temp_b, rows, intermediate_size, NULL, 0);
+        const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+        kernel<<<gridDim, blockDim, 0, stream>>>temp_a, temp_b, rows, intermediate_size, NULL, 0);
     }
 
     // Up proj without gate


### PR DESCRIPTION
In order for cuda graphs to be capturable, kernels need to be launched on specific stream.
Importantly for pytorch, it must be the same stream as other regular kernels.

This PR is just a demonstration of how to do it.

I do not have a short reproducible script, but a simple.

```python
g = torch.cuda.CUDAGraph()
with torch.cuda.graph(g):
     .....
     
g.replay()
```
Should be enough.

If this PR is accepted in some form, I can work on updating the other kernels.