### PR TITLE
Fix in ext.py (index error on system without GPU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ExLlamaV2 is an inference library for running local LLMs on modern consumer GPUs.
 
+The official and recommended backend server for ExLlamaV2 is [TabbyAPI](https://github.com/theroyallab/tabbyAPI/),
+which provides an OpenAI-compatible API for local or remote inference, with extended features like HF model
+downloading, embedding model support and support for HF Jinja2 chat templates.
+
+See the [wiki](https://github.com/theroyallab/tabbyAPI/wiki/1.-Getting-Started) for help getting started.
+
 
 ## New in v0.1.0+:
 

--- a/exllamav2/ext.py
+++ b/exllamav2/ext.py
@@ -39,6 +39,8 @@ def maybe_set_arch_list_env():
         arch = f'{capability[0]}.{capability[1]}'
         if arch not in arch_list:
             arch_list.append(arch)
+    if not arch_list:
+        return
     arch_list = sorted(arch_list)
     arch_list[-1] += '+PTX'
 


### PR DESCRIPTION
Without this exllamav2 can't even be imported on a system without GPU:

```
...python3.11/site-packages/exllamav2/ext.py:43: in maybe_set_arch_list_env
    arch_list[-1] += '+PTX'
E   IndexError: list index out of range
```