### PR TITLE
Improvement to enable quantization of Merge Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## About this Fork
+
+This fork includes the changes needed to quantize Merge models (models made by merging others instead of finetuning).
+
 # ExLlamaV2
 
 ExLlamaV2 is an inference library for running local LLMs on modern consumer GPUs.

--- a/exllamav2/attn.py
+++ b/exllamav2/attn.py
@@ -16,6 +16,7 @@ import math
 import torch.nn.functional as F
 import inspect
 import os
+from exllamav2.util import substitute_inf_with_max
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -964,17 +965,17 @@ class ExLlamaV2Attention(ExLlamaV2Module):
         use_flash_attn = has_flash_attn and not cfg.no_flash_attn
 
         if isinstance(attn_params, ExLlamaV2Attention.PagedParams):
-            return self.forward_paged(
+            return substitute_inf_with_max(self.forward_paged(
                 hidden_states,
                 cache,
                 attn_params,
                 loras = loras,
                 **kwargs
-            )
+            ))
 
         if self.is_tp:
             if cache is not None and use_flash_attn:
-                return self.forward_tp(
+                return substitute_inf_with_max(self.forward_tp(
                     hidden_states,
                     cache,
                     attn_params,
@@ -982,11 +983,11 @@ class ExLlamaV2Attention(ExLlamaV2Module):
                     intermediates,
                     loras,
                     **kwargs,
-                )
+                ))
             else:
                 # TODO: Can't use the optimized forward function because it writes directly to a fixed output
                 #   tensor, and flash-attn currently has a bug that prevents that from working when q_len == 1
-                return self.forward_tp_old(
+                return substitute_inf_with_max(self.forward_tp_old(
                     hidden_states,
                     cache,
                     attn_params,
@@ -994,7 +995,7 @@ class ExLlamaV2Attention(ExLlamaV2Module):
                     intermediates,
                     loras,
                     **kwargs,
-                )
+                ))
 
         if self.q_handle is None or intermediates:
             return self.forward_torch(
@@ -1113,7 +1114,7 @@ class ExLlamaV2Attention(ExLlamaV2Module):
         if cfg.arch.clamp_hidden_states:
             hidden_states.clamp_(-65504, 65504)
 
-        return hidden_states
+        return substitute_inf_with_max(hidden_states)
 
     def forward_tp(
         self,
@@ -1428,9 +1429,9 @@ class ExLlamaV2Attention(ExLlamaV2Module):
         if intermediates:
             return {"post_norm": post_norm,
                     "attn_output": attn_output,
-                    "hidden_states": hidden_states}
+                    "hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)
 
 
     def update_loras(self):

--- a/exllamav2/embedding.py
+++ b/exllamav2/embedding.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from exllamav2.model import ExLlamaV2
 
+from exllamav2.util import substitute_inf_with_max
+
 EMBEDDING_INDEX: int = 1000000
 
 class ExLlamaV2Embedding(ExLlamaV2Module):
@@ -185,6 +187,6 @@ class ExLlamaV2Embedding(ExLlamaV2Module):
             hidden_states = ctx.copy_pinned(0, hidden_states)
 
         if intermediates:
-            return {"hidden_states": hidden_states}
+            return {"hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)

--- a/exllamav2/headnorm.py
+++ b/exllamav2/headnorm.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from exllamav2.model import ExLlamaV2
 
+from exllamav2.util import substitute_inf_with_max
+
 class ExLlamaV2HeadNorm(ExLlamaV2Module):
 
     name: str = "LayerNorm"
@@ -122,9 +124,9 @@ class ExLlamaV2HeadNorm(ExLlamaV2Module):
                         self.variance_epsilon)
 
         if intermediates:
-            return {"hidden_states": hidden_states}
+            return {"hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)
 
     def forward_torch(
         self,
@@ -146,8 +148,8 @@ class ExLlamaV2HeadNorm(ExLlamaV2Module):
         hidden_states = hidden_states.to(input_dtype)
 
         if intermediates:
-            return {"hidden_states": hidden_states}
+            return {"hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)
 
 

--- a/exllamav2/layernorm.py
+++ b/exllamav2/layernorm.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from exllamav2.model import ExLlamaV2
 
+from exllamav2.util import substitute_inf_with_max
+
 class ExLlamaV2LayerNorm(ExLlamaV2Module):
 
     name: str = "LayerNorm"
@@ -119,9 +121,9 @@ class ExLlamaV2LayerNorm(ExLlamaV2Module):
         hidden_states = norm.view(output_shape)
 
         if intermediates:
-            return {"hidden_states": hidden_states}
+            return {"hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)
 
 
     def forward_torch(
@@ -139,8 +141,8 @@ class ExLlamaV2LayerNorm(ExLlamaV2Module):
         hidden_states = self.layernorm(hidden_states)
 
         if intermediates:
-            return {"hidden_states": hidden_states}
+            return {"hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)
 
 

--- a/exllamav2/model.py
+++ b/exllamav2/model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import os, sys
 
 from exllamav2.architecture import RopeStyle
+from exllamav2.util import substitute_inf_with_max
 
 min_version = (3, 8)
 if sys.version_info < min_version:
@@ -820,9 +821,9 @@ class ExLlamaV2:
             if abort_event and abort_event.is_set(): return
 
             if "last_state" in result:
-                return result.get("logits"), result["last_state"]
+                return substitute_inf_with_max(result.get("logits")), substitute_inf_with_max(result["last_state"])
             else:
-                return result.get("logits")
+                return substitute_inf_with_max(result.get("logits"))
 
         # Confirm that the input fits within the allocated cache space
 
@@ -893,9 +894,9 @@ class ExLlamaV2:
             last_state = r.get("last_state")
 
         if last_state is None:
-            return result
+            return substitute_inf_with_max(result)
         else:
-            return result, last_state
+            return substitute_inf_with_max(result), substitute_inf_with_max(last_state)
 
 
     @torch.inference_mode()

--- a/exllamav2/module.py
+++ b/exllamav2/module.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from exllamav2.config import ExLlamaV2Config
 from exllamav2.fasttensors import STFile
 from exllamav2.compat import safe_move_tensor
+from exllamav2.util import substitute_inf_with_max
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -282,4 +283,4 @@ class Intervention(ExLlamaV2Module):
             hidden_states = self.post_forward(hidden_states, *args, **kwargs)
             hidden_states = safe_move_tensor(hidden_states, dev)
 
-        return hidden_states
+        return substitute_inf_with_max(hidden_states)

--- a/exllamav2/moe_mlp.py
+++ b/exllamav2/moe_mlp.py
@@ -7,6 +7,7 @@ from exllamav2.layernorm import ExLlamaV2LayerNorm
 from exllamav2.linear import ExLlamaV2Linear
 from exllamav2.lora import ExLlamaV2Lora
 from exllamav2.ext import exllamav2_ext as ext_c, none_tensor
+from exllamav2.util import substitute_inf_with_max
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -244,7 +245,7 @@ class ExLlamaV2MoEMLP(ExLlamaV2Module):
         # ext_c.q_moe_mlp_forward_(self.q_handle, hidden_states.view(-1, hidden_states.shape[-1]), pass_loras, pass_lora_temp)
         ext_c.q_moe_mlp_forward_(self.q_handle, hidden_states.view(-1, hidden_states.shape[-1]))
 
-        return hidden_states
+        return substitute_inf_with_max(hidden_states)
 
 
     def forward_torch(
@@ -313,9 +314,9 @@ class ExLlamaV2MoEMLP(ExLlamaV2Module):
 
         if intermediates:
             result["hidden_states"] = final_hidden_states
-            return result
+            return substitute_inf_with_max(result)
         else:
-            return final_hidden_states
+            return substitute_inf_with_max(final_hidden_states)
 
 
     def update_loras(self):

--- a/exllamav2/parallel_decoder.py
+++ b/exllamav2/parallel_decoder.py
@@ -9,6 +9,7 @@ from exllamav2.rmsnorm import ExLlamaV2RMSNorm
 from exllamav2.lora import ExLlamaV2Lora
 from exllamav2.layernorm import ExLlamaV2LayerNorm
 from exllamav2.ext import exllamav2_ext as ext_c, none_tensor
+from exllamav2.util import substitute_inf_with_max
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -119,7 +120,7 @@ class ExLlamaV2ParallelDecoder(ExLlamaV2Module):
         b = self.mlp.forward(b, cache, attn_params, past_len, intermediates, loras, **kwargs)
         hidden_states += a
         hidden_states += b
-        return hidden_states
+        return substitute_inf_with_max(hidden_states)
 
 
     def forward_interm(

--- a/exllamav2/pos_embedding.py
+++ b/exllamav2/pos_embedding.py
@@ -4,6 +4,7 @@ from torch import nn
 from exllamav2.module import ExLlamaV2Module
 from exllamav2.attn import ExLlamaV2Attention
 from exllamav2.compat import safe_move_tensor
+from exllamav2.util import substitute_inf_with_max
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -118,6 +119,6 @@ class ExLlamaV2PosEmbedding(ExLlamaV2Module):
                 hidden_states[b, target_a:target_b] += emb_slice
 
         if intermediates:
-            return {"hidden_states": hidden_states}
+            return {"hidden_states": substitute_inf_with_max(hidden_states)}
         else:
-            return hidden_states
+            return substitute_inf_with_max(hidden_states)

--- a/exllamav2/util.py
+++ b/exllamav2/util.py
@@ -368,3 +368,12 @@ def pack_4bit(unpacked: torch.Tensor):
         packed |= (unpacked[:, i::8].to(torch.int64) << (i * 4))
     packed = packed.to(torch.int32)
     return packed
+
+
+# Example function to substitute inf with the maximum value of the type
+def substitute_inf_with_max(tensor):
+    dtype = tensor.dtype
+    max_value = torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
+    tensor = torch.where(torch.isinf(tensor), max_value, tensor)
+    tensor = torch.where(torch.isnan(tensor), max_value, tensor)
+    return tensor


### PR DESCRIPTION
Fixes Inf and NaN values in the tensors that happen in the models produced by the merge of others. In those cases the inf values are replaced by MAX_VALUE.

I have successfully tested it in the quantization of invisietch/Nimbus-Miqu-v0.1-70B.