### PR TITLE
Add `ExLlamaV2Sampler.Settings.logits_processor`

### DIFF
--- a/examples/json_schema_outlines.py
+++ b/examples/json_schema_outlines.py
@@ -1,0 +1,108 @@
+# Install Outlines:
+# pip install outlines
+
+# Download Model:
+# huggingface-cli download bartowski/Phi-3.1-mini-4k-instruct-exl2 --revision 6_5 --local-dir Phi-3.1-mini-4k-instruct-exl2-6_5
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+
+from exllamav2 import ExLlamaV2, ExLlamaV2Config, ExLlamaV2Cache, ExLlamaV2Tokenizer
+from exllamav2.generator import ExLlamaV2DynamicGenerator, ExLlamaV2Sampler
+
+from outlines.processors import JSONLogitsProcessor
+from outlines.models.exllamav2 import patch_tokenizer as patch_exl2_tokenizer_for_outlines
+
+from pydantic import BaseModel, Field, RootModel
+from typing import Optional, Union, Literal
+from datetime import time
+
+
+################################################
+# Create Structured JSON Generator With Outlines
+################################################
+
+# Additional Examples: https://outlines-dev.github.io/outlines/cookbook/
+# JSON Generation Docs: https://outlines-dev.github.io/outlines/reference/json/
+# `outlines.processors` also supports guaranteed regex patterns and lark grammars
+
+# Example: Home Assistant extension for natural language commands -> actions
+class LightAction(BaseModel):
+    entity: Literal["light"] = "light"
+    action: Literal["turn_on", "turn_off", "set_brightness"]
+    brightness: Optional[int] = Field(None, ge=0, le=100)
+    execute_at: Optional[time] = None
+
+
+class OvenAction(BaseModel):
+    entity: Literal["oven"] = "oven"
+    action: Literal["turn_on", "turn_off", "set_temperature"]
+    temperature: Optional[float] = Field(None, ge=50, le=300)
+    execute_at: Optional[time] = None
+
+
+class HomeAssistantAction(BaseModel):
+    instruction: Union[LightAction, OvenAction]
+
+
+def create_generator(model_dir="/mnt/str/models/mistral-7b-exl2/4.0bpw"):
+    config = ExLlamaV2Config(model_dir)
+    config.arch_compat_overrides()
+    model = ExLlamaV2(config)
+    cache = ExLlamaV2Cache(model, max_seq_len=32768, lazy=True)
+    model.load_autosplit(cache, progress=True)
+
+    print("Loading tokenizer...")
+    tokenizer = ExLlamaV2Tokenizer(config)
+    tokenizer.vocabulary = tokenizer.extended_piece_to_id
+
+    # Initialize the generator with all default parameters
+    return ExLlamaV2DynamicGenerator(
+        model=model,
+        cache=cache,
+        tokenizer=tokenizer,
+    )
+
+
+generator = create_generator("./Phi-3.1-mini-4k-instruct-exl2-6_5")
+
+gen_settings = ExLlamaV2Sampler.Settings()
+gen_settings.logits_processor = JSONLogitsProcessor(
+    HomeAssistantAction,
+    patch_exl2_tokenizer_for_outlines(generator.tokenizer)
+)
+
+
+rules = "JSON for an instruction with an entity (light or oven) and action (turn_on, turn_off, set_brightness, set temperature). *Optionally* you may set an execute_at time-of-day if the user specifies, otherwise set to null"
+prompts = [
+    f"<|user|> {rules} Turn the lights lower please!<|end|><|assistant|>",
+    f"<|user|> {rules} I need the oven set for homemade pizza when I get home from work at 6PM.<|end|><|assistant|>",
+    f"<|user|> {rules} Oh no the lights are off and I can't find the switch!<|end|><|assistant|>",
+]
+
+outputs = generator.generate(
+    prompt=prompts,
+    gen_settings=gen_settings,
+    max_new_tokens=2048,
+    completion_only=True,
+    encode_special_tokens=False,
+    stop_conditions=[generator.tokenizer.eos_token_id],
+)
+
+# raw json format
+for idx, output in enumerate(outputs):
+    print(output)
+# Output:
+# {"instruction": {"entity": "light", "action": "set_brightness", "execute_at": null}}
+# {"instruction": {"entity": "oven", "action": "set_temperature", "execute_at": "18:00:00"} }
+# {"instruction": {"entity": "light", "action": "turn_on"}}
+
+# pydantic model format
+for idx, output in enumerate(outputs):
+    print(repr(HomeAssistantAction.parse_raw(output)))
+# Output:
+# HomeAssistantAction(instruction=LightAction(entity='light', action='set_brightness', brightness=None, execute_at=None))
+# HomeAssistantAction(instruction=OvenAction(entity='oven', action='set_temperature', temperature=None, execute_at=datetime.time(18, 0)))
+# HomeAssistantAction(instruction=LightAction(entity='light', action='turn_on', brightness=None, execute_at=None))

--- a/exllamav2/generator/base.py
+++ b/exllamav2/generator/base.py
@@ -193,6 +193,8 @@ class ExLlamaV2BaseGenerator:
                                                           return_offsets = True,
                                                           add_bos = add_bos)
 
+            pre_ids = torch.empty(*ids.shape[:-1], 0)
+
             if prompts_identical:
                 position_offsets = None
 
@@ -268,6 +270,7 @@ class ExLlamaV2BaseGenerator:
             ExLlamaV2Sampler.sample(
                 logits,
                 gen_settings,
+                pre_ids,
                 self.sequence_ids,
                 random.random(),
                 self.tokenizer,

--- a/exllamav2/generator/dynamic.py
+++ b/exllamav2/generator/dynamic.py
@@ -74,7 +74,7 @@ class CachePage:
     kv_position: int
     kv_position_revert: int
     # Specific tokens for which KV is valid assuming prev_hash
-    sequence: torch.Tensor
+    sequence: torch.Tensors
     can_revert: bool
     # Used by defragmenter
     new_page_index: int
@@ -525,7 +525,7 @@ class ExLlamaV2DynamicGenerator:
             self.current_loras = loras
         else:
             self.current_loras = [loras]
-        
+
 
     def generate(
         self,
@@ -1766,6 +1766,7 @@ class ExLlamaV2DynamicJob:
         ExLlamaV2Sampler.sample(
             logits,
             self.gen_settings,
+            self.sequences[0].input_ids.torch(),
             self.sequences[0].sequence_ids.torch(),
             self.rng.random(),
             self.generator.tokenizer,

--- a/tests/test_logits_processor.py
+++ b/tests/test_logits_processor.py
@@ -1,0 +1,326 @@
+
+import sys, os, gc, time, random
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from exllamav2 import(
+    ExLlamaV2,
+    ExLlamaV2Config,
+    ExLlamaV2CacheBase,
+    ExLlamaV2Cache,
+    ExLlamaV2Cache_8bit,
+    ExLlamaV2Tokenizer,
+)
+
+from exllamav2.generator import (
+    ExLlamaV2BaseGenerator,
+    ExLlamaV2StreamingGenerator,
+    ExLlamaV2Sampler
+)
+
+import time
+
+model: ExLlamaV2
+config: ExLlamaV2Config
+tokenizer: ExLlamaV2Tokenizer
+cache: ExLlamaV2CacheBase
+
+
+class SamplerLogitsProcessor:
+    def __init__(
+        self,
+        temperature: float = 1.0,
+        top_k: int = 0,
+        top_p: float = 0.0,
+        top_a: float = 0.0,
+        disallow_tokens: list = [],
+    ):
+        if temperature <= 0:
+            raise ValueError("Temperature must be > 0.")
+        if top_k < 0:
+            raise ValueError("top_k must be >= 0.")
+        if not (0.0 <= top_p <= 1.0):
+            raise ValueError("top_p must be between 0 and 1.")
+        if top_a < 0:
+            raise ValueError("top_a must be >= 0.")
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
+        self.top_a = top_a
+        self.disallow_tokens = torch.tensor(disallow_tokens)
+
+    @torch.no_grad()
+    def __call__(self, input_ids, logits):
+        # Apply temperature scaling
+        if self.temperature != 1.0:
+            logits /= self.temperature
+
+        # Initialize mask
+        mask = torch.zeros_like(logits, dtype=torch.bool)
+
+        if self.top_p > 0.0 or self.top_a > 0.0:
+            probs = torch.nn.functional.softmax(logits, dim=-1)
+            sorted_probs, sorted_indices = probs.sort(descending=True, dim=-1)
+
+            # Apply top-p filtering
+            if self.top_p > 0.0:
+                cumulative_probs = sorted_probs.cumsum(dim=-1)
+                sorted_mask = cumulative_probs > self.top_p
+                sorted_mask = sorted_mask.roll(shifts=1, dims=-1)
+                sorted_mask[..., 0] = False
+                mask.scatter_(-1, sorted_indices, sorted_mask)
+
+            # Apply top-a filtering
+            if self.top_a > 0.0:
+                max_probs = sorted_probs[:, 0].unsqueeze(-1)
+                mask |= probs < (max_probs / self.top_a)
+
+        # top-k: logits > kth largest value's logits
+        if self.top_k > 0:
+            threshold = logits.topk(self.top_k, dim=-1, largest=True).values[..., -1, None]
+            mask |= logits < threshold  # Compare logits directly with the threshold
+
+        # Filter disallowed tokens
+        if self.disallow_tokens is not None and self.disallow_tokens.numel() > 0:
+            self.disallow_tokens = self.disallow_tokens.to(device=logits.device)
+            mask.index_fill_(-1, self.disallow_tokens, True)
+
+        # Apply the mask
+        logits.masked_fill_(mask, -float("inf"))
+        return logits
+
+
+
+def unload():
+    global model, config, tokenizer, cache
+
+    model.unload()
+    model = None
+    config = None
+    cache = None
+    tokenizer = None
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def load_model(model_dir, split = None, cache_8bit = False):
+    global model, config, tokenizer, cache
+
+    config = ExLlamaV2Config()
+    config.model_dir = model_dir
+    config.prepare()
+
+    model = ExLlamaV2(config)
+    print(" -- Loading model: " + model_dir)
+
+    model.load(split)
+
+    tokenizer = ExLlamaV2Tokenizer(config)
+
+    if cache_8bit:
+        print(" -- Creating 8-bit cache")
+        cache = ExLlamaV2Cache_8bit(model, batch_size = 4)
+    else:
+        print(" -- Creating 16-bit cache")
+        cache = ExLlamaV2Cache(model, batch_size = 4)
+
+
+def test_gen_normal(prompt, max_new_tokens):
+    global model, config, tokenizer, cache
+
+    print("--------------------------------")
+    print("Generating, normal")
+    print()
+
+    generator = ExLlamaV2BaseGenerator(model, cache, tokenizer)
+
+    settings = ExLlamaV2Sampler.Settings()
+    settings.logits_processor = SamplerLogitsProcessor(
+        temperature=0.85,
+        top_k=50,
+        top_p=0.8,
+        top_a=0.0,
+        disallow_tokens=[tokenizer.eos_token_id],
+    )
+
+    generator.warmup()
+    time_begin = time.time()
+
+    output = generator.generate_simple(prompt, settings, max_new_tokens, seed=1234)
+
+    time_end = time.time()
+    time_total = time_end - time_begin
+
+    print(output)
+    print()
+    print(f"Response generated in {time_total:.2f} seconds, {max_new_tokens} tokens, {max_new_tokens / time_total:.2f} tokens/second")
+
+
+def test_gen_streaming(prompt, max_new_tokens):
+    global model, config, tokenizer, cache
+
+    print("--------------------------------")
+    print("Generating, streaming")
+    print()
+
+    generator = ExLlamaV2StreamingGenerator(model, cache, tokenizer)
+
+    settings = ExLlamaV2Sampler.Settings()
+    settings.logits_processor = SamplerLogitsProcessor(
+        temperature=0.85,
+        top_k=50,
+        top_p=0.8,
+        top_a=0.0,
+        disallow_tokens=[tokenizer.eos_token_id],
+    )
+
+    input_ids = tokenizer.encode(prompt)
+    prompt_tokens = input_ids.shape[-1]
+
+    print(prompt, end = "")
+    sys.stdout.flush()
+
+    time_begin_prompt = time.time()
+
+    generator.set_stop_conditions([])
+    generator.begin_stream(input_ids, settings)
+
+    time_begin_stream = time.time()
+    generated_tokens = 0
+
+    while True:
+        chunk, eos, _ = generator.stream()
+        generated_tokens += 1
+        print(chunk, end = "")
+        sys.stdout.flush()
+        if eos or generated_tokens == max_new_tokens: break
+
+    time_end = time.time()
+
+    time_prompt = time_begin_stream - time_begin_prompt
+    time_tokens = time_end - time_begin_stream
+
+    print()
+    print()
+    print(f"Prompt processed in {time_prompt:.2f} seconds, {prompt_tokens} tokens, {prompt_tokens / time_prompt:.2f} tokens/second")
+    print(f"Response generated in {time_tokens:.2f} seconds, {generated_tokens} tokens, {generated_tokens / time_tokens:.2f} tokens/second")
+
+
+def test_gen_batch(max_new_tokens):
+
+    print("--------------------------------")
+    print("Generating, batched")
+    print()
+
+    generator = ExLlamaV2BaseGenerator(model, cache, tokenizer)
+
+    settings = ExLlamaV2Sampler.Settings()
+    settings.logits_processor = SamplerLogitsProcessor(
+        temperature=0.85,
+        top_k=50,
+        top_p=0.8,
+        top_a=0.0,
+        disallow_tokens=[tokenizer.eos_token_id],
+    )
+
+    generator.warmup()
+    time_begin = time.time()
+
+    prompts = ["Here's how to create a powerful love potio",
+               "For once,",
+               "The events of the American Civil W",
+               "A bird in the hand is worth"]
+
+    output = generator.generate_simple(prompts, settings, max_new_tokens, seed = 1234, token_healing = True)
+
+    time_end = time.time()
+    time_total = time_end - time_begin
+
+    for o in output:
+        print(o)
+        print("---")
+    print()
+    print(f"Response generated in {time_total:.2f} seconds, {max_new_tokens} tokens, throughput {4 * max_new_tokens / time_total:.2f} tokens/second")
+
+
+def test_multicache(max_new_tokens):
+
+    print("--------------------------------")
+    print("Generating, batched multi cache")
+    print()
+
+    settings = ExLlamaV2Sampler.Settings()
+    settings.logits_processor = SamplerLogitsProcessor(
+        temperature=0.85,
+        top_k=50,
+        top_p=0.8,
+        top_a=0.0,
+        disallow_tokens=[tokenizer.eos_token_id],
+    )
+
+    prompts = ["Here's how to create a powerful love potion",
+               "For once,",
+               "The events of the American Civil War",
+               "A bird in the hand is worth"]
+
+    caches = [ExLlamaV2Cache(model, max_seq_len = 256) for _ in range(len(prompts))]
+    input_ids = []
+
+    for i in range(len(prompts)):
+
+        input_ids.append(tokenizer.encode(prompts[i]))
+        model.forward(input_ids[i][:, :-1], caches[i], input_mask = None, preprocess_only = True)
+
+    time_begin = time.time()
+
+    for i in range(max_new_tokens):
+
+        inputs = torch.cat([x[:, -1:] for x in input_ids], dim = 0)
+        logits = model.forward(inputs, caches, input_mask = None).float().cpu()
+
+        r = random.random()
+        for j in range(len(input_ids)):
+            token, _, _ = ExLlamaV2Sampler.sample(logits[j:j + 1, :, :], settings, input_ids[j], r, tokenizer)
+            input_ids[j] = torch.cat([input_ids[j], token], dim = 1)
+
+    output = [tokenizer.decode(ids)[0] for ids in input_ids]
+
+    time_end = time.time()
+    time_total = time_end - time_begin
+
+    for o in output:
+        print(o)
+        print("---")
+    print()
+    print(f"Response generated in {time_total:.2f} seconds, {max_new_tokens} tokens, throughput {4 * max_new_tokens / time_total:.2f} tokens/second")
+
+
+def tests(model_dir, cache_8bit, use_split):
+
+    if use_split: split = [1, 24]
+    else: split = None
+    print("--------------------------------")
+    print(f" -- Split: {split}")
+    load_model(model_dir, split = split, cache_8bit = cache_8bit)
+
+    test_gen_normal("Our story begins in the Scottish town of Auchtermuchty, where once", 150)
+    test_gen_streaming("Our story begins in the Scottish town of Auchtermuchty, where once", 150)
+    test_gen_batch(40)
+    if model.is_quant(): test_multicache(40)
+
+    unload()
+
+
+q_model_directory = "/mnt/str/models/mistral-7b-instruct-exl2/4.0bpw/"
+f_model_directory = "/mnt/str/models/tinyllama-1b-ckpt503/"
+
+tests(q_model_directory, False, False)
+tests(q_model_directory, False, True)
+tests(q_model_directory, True, False)
+tests(q_model_directory, True, True)
+tests(f_model_directory, False, False)
+tests(f_model_directory, False, True)
+tests(f_model_directory, True, False)
+tests(f_model_directory, True, True)


### PR DESCRIPTION
# Overview / Motivation
Implements `ExLlamaV2Sampler.Settings.logits_processor` which allows us to
- Take advantage of third party libraries logits processors, such as Outlines which implements JSON Schema, regex, and Lark structured generation logits processors
- Enable implementation ofnew sampling techniques through torch-based logits processors
- Have a path towards faster sampling through keeping `logits` on GPU and using torch, rather than sampling on CPU.

## Changes
- Introduce `ExLlamaV2Sampler.Settings.logits_processor` which allows for logits filtering and augmentation with torch
  - Make necessary changes to generation-related code to ensure logits processor is applied
- Introduce `tests/test_logits_processors.py` which is the same as `tests/test.py` but using a logits processor for all sampling
- Introduce `examples/json_schema_outlines.py`

## Performance
- No change in performance for `tests.py` between this branch and `master`
- Slower when optional `logits_processor` argument is enabled
  - This builds a path for a future change where, ExLlamaV2 sampling is even **faster** by keeping `logits` and `input_ids` on GPU and using torch (out of scope for this PR


| Test                                    | normal | streaming (prompt) | streaming (response) | batched |
|-----------------------------------------|-------------------:|------------------------------:|---------------------------------:|--------------------:|
| master -> tests.py                      |             157.71 |                      3491.57  |                          179.95 |               10.14 |
| this branch -> tests.py                 |             158.39 |                      3559.52  |                          178.04 |               10.15 |
| this branch -> test_logits_processor.py |             122.66 |                      3576.11  |                          134.56 |                9.97 |



<details>

`master` -> `tests.py`
```
Generating, normal
...
Response generated in 1.51 seconds, 150 tokens, 99.38 tokens/second

Generating, streaming
...
Prompt processed in 0.00 seconds, 15 tokens, 3693.04 tokens/second
Response generated in 1.10 seconds, 150 tokens, 136.67 tokens/second

Generating, batched
...
Response generated in 17.87 seconds, 40 tokens, throughput 8.95 tokens/second
```
(Note: `Generating, batched multi cache` fails in `master`, not due to this PR)

`sampler-logits-processor` -> `tests.py`

```
Generating, normal
...
Response generated in 1.51 seconds, 150 tokens, 99.46 tokens/second

Generating, streaming
...
Prompt processed in 0.00 seconds, 15 tokens, 3534.72 tokens/second                                                            
Response generated in 1.12 seconds, 150 tokens, 133.63 tokens/second                                                          

Generating, batched
...
Response generated in 18.26 seconds, 40 tokens, throughput 8.76 tokens/second
```

`sampler-logits-processor` -> `test_logits_processor.py`
```
Generating, normal
...
Response generated in 1.22 seconds, 150 tokens, 122.66 tokens/second

Generating, streaming
...
Prompt processed in 0.00 seconds, 15 tokens, 3576.11 tokens/second
Response generated in 1.11 seconds, 150 tokens, 134.56 tokens/second

Generating, batched
...
Response generated in 16.04 seconds, 40 tokens, throughput 9.97 tokens/second
```

</details>

# Tests

All tests pass except for `tests/test.py` / `Generating, batched multi cache` which also fails in `master` 

<details>

```
Generating, batched multi cache

Traceback (most recent call last):
  File "/root/exllamav2/tests/test.py", line 249, in <module>
    tests(q_model_directory, False, False)
  File "/root/exllamav2/tests/test.py", line 241, in tests
    if model.is_quant(): test_multicache(40)
  File "/root/exllamav2/tests/test.py", line 211, in test_multicache
    logits = model.forward(inputs, caches, input_mask = None).float().cpu()
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/root/exllamav2/exllamav2/model.py", line 809, in forward
    result = self.forward_chunk(input_ids = input_ids,
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/root/exllamav2/exllamav2/model.py", line 922, in forward_chunk
    past_len = cache.current_seq_len
AttributeError: 'list' object has no attribute 'current_seq_len'
```

</details>