### PR TITLE
enable module type checking

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include exllamav2 *
+global-include *.typed
 global-exclude *.pyc
 global-exclude dni_*

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,9 @@ setup(
         "rich"
     ],
     include_package_data = True,
+    package_data={
+        "": ["py.typed"],  # This will include py.typed in all packages
+    },
     verbose = verbose,
     **setup_kwargs,
 )


### PR DESCRIPTION
This PR adds module support for type checking using mypy, so that external projects that depend on exllamav2 can use static type checking.

Previously, when using exllamav2 you would experience the following error

```
error: Skipping analyzing "exllamav2": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```