### PR TITLE
Prevent UnboundLocalError when loading with yarn/su with short ctx len

### DIFF
--- a/exllamav2/rope.py
+++ b/exllamav2/rope.py
@@ -23,6 +23,7 @@ def get_rope_params_su(
         scaling_factor = math.sqrt(1 + math.log(a / b) / math.log(b))
     else:
         ext_factors = torch.tensor(cfg.scale_short_factor, dtype = torch.float32, device = device)
+        scaling_factor = 1.0
 
     inv_freq = 1.0 / (ext_factors * base ** (torch.arange(0, head_dim, 2, device = device).float() / head_dim))
     return inv_freq, scaling_factor
@@ -133,6 +134,7 @@ def get_rope_params_yarn(
         )
     else:
         inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, device=device).float() / head_dim))
+        scaling_factor = 1.0
 
     return inv_freq, scaling_factor
 


### PR DESCRIPTION
When loading a model with yarn or su scaling, `scaling_factor` is left unbound when the requested `max_seq_len` <= the model's original unscaled `max_seq_len`, resulting in an UnboundLocalError.

For example when loading a Qwen2 Instruct model with the suggested yarn settings:
```json
{
  ...,
  "rope_scaling": {
    "factor": 4.0,
    "original_max_position_embeddings": 32768,
    "type": "yarn"
  }
}
```
and subsequently loading the model with a `max_seq_len` of 32768 or less.