### PR TITLE
fix divide by zero error if there's no error in the optimization.

### DIFF
--- a/exllamav2/conversion/optimize.py
+++ b/exllamav2/conversion/optimize.py
@@ -180,7 +180,8 @@ def optimize(job, save_fn, model):
             bpw = p["total_bits"] / n
             err = 1 - p["accuracy"]
             print(f" --   {k:50} {bpw:1.4f} bpw - exp. error: {err:1.8f}")
-            logerr += math.log(err)
+            if err != 0:
+                logerr += math.log(err)
             maxerr = max(err, maxerr)
 
     print(f" -- sum(log(err)): {logerr:.6f}")


### PR DESCRIPTION
Ran into this while running convert against a sketchy model.