### PR TITLE
fix: compile error on RDNA4 (gfx1201) ROCm

### DIFF
--- a/exllamav2/exllamav2_ext/cuda/layer_norm.cu
+++ b/exllamav2/exllamav2_ext/cuda/layer_norm.cu
@@ -5,10 +5,14 @@
 #if defined(USE_ROCM)
 #define NUM_WARPS (1024 / warpSize)
 #define WARP_SIZE (warpSize)
+#define MAX_NUM_WARPS 32
 #else
 #define NUM_WARPS 32
 #define WARP_SIZE 32
+#define MAX_NUM_WARPS 32
 #endif
+
+#define NUM_THREADS_CONST 1024
 
 // y = x * w / sqrt(row_mean(x * x) + epsilon)
 
@@ -75,7 +79,7 @@ __global__ void layer_norm_kernel
 
     // Shuffle to sum across lanes
 
-    __shared__ float sums[NUM_WARPS];
+    __shared__ float sums[MAX_NUM_WARPS];
 
     for(int offset = warpSize / 2; offset > 0; offset /= 2) sum += __shfl_xor_sync(0xffffffff, sum, offset);
     if (lane_id == 0) sums[warp_id] = sum;
@@ -198,14 +202,14 @@ void layer_norm_cuda
 )
 {
     dim3 blockDim, gridDim;
-    blockDim.x = NUM_THREADS;
+    blockDim.x = NUM_THREADS_CONST;
     blockDim.y = 1;
     gridDim.x = rows;
     gridDim.y = 1;
 
     float r_dim = 1.0f / (float) dim;
 
-    int blocks_per_warp = DIVIDE(dim, NUM_THREADS * 2);
+    int blocks_per_warp = DIVIDE(dim, NUM_THREADS_CONST * 2);
     fp_layer_norm_kernel kernel = pick_layer_norm_kernel(blocks_per_warp);
     kernel<<<gridDim, blockDim, 0, stream>>>(x, w, b, y, epsilon, r_dim, rows, dim, add_residual);
     if (graph) graph->attach_label(stream, label, 0);

--- a/exllamav2/exllamav2_ext/cuda/rms_norm.cu
+++ b/exllamav2/exllamav2_ext/cuda/rms_norm.cu
@@ -5,10 +5,16 @@
 #if defined(USE_ROCM)
 #define NUM_WARPS (1024 / warpSize)
 #define WARP_SIZE (warpSize)
+#define MAX_NUM_WARPS 32
 #else
 #define NUM_WARPS 32
 #define WARP_SIZE 32
+#define MAX_NUM_WARPS 32
 #endif
+
+// NUM_WARPS * WARP_SIZE is always 1024 regardless of warp size.
+// Use this in host code where warpSize (__device__ variable) is unavailable.
+#define NUM_THREADS_CONST 1024
 
 // y = x * w / sqrt(row_mean(x * x) + epsilon)
 
@@ -98,7 +104,7 @@ __global__ void rms_norm_kernel
 
     // Shuffle to sum across lanes
 
-    __shared__ float sums[NUM_WARPS];
+    __shared__ float sums[MAX_NUM_WARPS];
 
     for(int offset = warpSize / 2; offset > 0; offset /= 2) sum += __shfl_xor_sync(0xffffffff, sum, offset);
     if (lane_id == 0) sums[warp_id] = sum;
@@ -215,14 +221,14 @@ void rms_norm_cuda
 )
 {
     dim3 blockDim, gridDim;
-    blockDim.x = NUM_THREADS;
+    blockDim.x = NUM_THREADS_CONST;
     blockDim.y = 1;
     gridDim.x = rows;
     gridDim.y = 1;
 
     float r_dim = 1.0f / (float) dim;
 
-    int blocks_per_warp = DIVIDE(dim, NUM_THREADS * 2);
+    int blocks_per_warp = DIVIDE(dim, NUM_THREADS_CONST * 2);
     fp_rms_norm_kernel kernel = pick_rms_norm_kernel(blocks_per_warp);
     kernel<<<gridDim, blockDim, 0, stream>>>(x, w, y, epsilon, r_dim, rows, dim, add_residual, input_fp32, output_fp32);
     if (graph) graph->attach_label(stream, label, 0);


### PR DESCRIPTION
## Summary —  AMD consumer GPUs
ExLlamaV2 fails to compile on RDNA4 GPUs (gfx1201: RX 9070, RX 9060, R9700) with ROCm 7.x.
`rms_norm.cu` and `layer_norm.cu` define `NUM_WARPS = 1024 / warpSize` under `USE_ROCM`. On HIP, `warpSize` is a runtime `__device__` variable (RDNA4 supports both wave32 and wave64), so `NUM_WARPS` is not a compile-time constant. This causes:
1. `__shared__ float sums[NUM_WARPS]` — variable length array in shared memory
2. Host functions referencing `NUM_THREADS` — `__device__` variable used in `__host__` context
error: variable length array declaration cannot have 'static' storage duration shared float sums[NUM_WARPS];
```
FAILED: rms_norm.cuda.o /opt/venv/lib/python3.12/site-packages/exllamav2/exllamav2_ext/hip/rms_norm.hip:103:22: error: variable length array declaration cannot have 'static' storage duration shared float sums[NUM_WARPS]; ^ ~~~~~~~~~

FAILED: layer_norm.cuda.o /opt/venv/lib/python3.12/site-packages/exllamav2/exllamav2_ext/hip/layer_norm.hip:80:22: error: variable length array declaration cannot have 'static' storage duration shared float sums[NUM_WARPS]; ^ ~~~~~~~~~

FAILED: rms_norm.cuda.o /workspace/exllamav2/exllamav2/exllamav2_ext/hip/rms_norm.hip:222:18: error: reference to device function 'operator int' in host function

FAILED: layer_norm.cuda.o /workspace/exllamav2/exllamav2/exllamav2_ext/hip/layer_norm.hip:205:18: error: reference to device function 'operator int' in host function
```
## Fix
Add compile-time constants `MAX_NUM_WARPS` (32) and `NUM_THREADS_CONST` (1024):
- `__shared__` arrays use `MAX_NUM_WARPS` (upper bound: 1024 / 32 = 32 warps)
- Host functions use `NUM_THREADS_CONST` (`NUM_WARPS * WARP_SIZE` = 1024 for all warp sizes)
- CUDA path unchanged — same values defined for both branches
## Test environment
- GPU: AMD Radeon R9700 Pro (gfx1201, RDNA 4), 32 GB VRAM
- ROCm: 7.2.3
- PyTorch: 2.9.1+rocm7.2.3
- Container: `rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.9.1`
## Test results
Build: `pip install --no-build-isolation -e .` — **success** (was failing before)
test_hgemm.py: 24/24 GEMM shapes passed 
```python
import torch
from exllamav2.ext import exllamav2_ext as ext_c

# Test RMS norm
dim = 4096
x = torch.randn(1, dim, dtype=torch.half, device='cuda:0')
w = torch.randn(dim, dtype=torch.half, device='cuda:0')
y = torch.empty_like(x)
ext_c.rms_norm(x, w, y, 1e-6)
print(f'rms_norm: input={x.shape}, output={y.shape}, has_nan={torch.isnan(y).any().item()}, has_inf={torch.isinf(y).any().item()}')

# Test Layer norm
x2 = torch.randn(1, dim, dtype=torch.half, device='cuda:0')
w2 = torch.randn(dim, dtype=torch.half, device='cuda:0')
b2 = torch.randn(dim, dtype=torch.half, device='cuda:0')
y2 = torch.empty_like(x2)
ext_c.layer_norm(x2, w2, b2, y2, 1e-6)
print(f'layer_norm: input={x2.shape}, output={y2.shape}, has_nan={torch.isnan(y2).any().item()}, has_inf={torch.isinf(y2).any().item()}')

print('ALL KERNEL TESTS PASSED')
"""output
rms_norm: input=torch.Size([1, 4096]), output=torch.Size([1, 4096]), has_nan=False, has_inf=False
layer_norm: input=torch.Size([1, 4096]), output=torch.Size([1, 4096]), has_nan=False, has_inf=False
ALL KERNEL TESTS PASSED
"""
```

