### PR TITLE
docs: fix incorrect long-flag names in eval.md and convert.md

### DIFF
--- a/doc/convert.md
+++ b/doc/convert.md
@@ -62,7 +62,7 @@ is 2048.
 - **-b / --bits *float***: Target average number of bits per weight.
   
 
-- **-hb / --bits *int***: Number of bits for the lm_head (output) layer of the model. Default is 6, although that
+- **-hb / --head_bits *int***: Number of bits for the lm_head (output) layer of the model. Default is 6, although that
 value actually results in a mixed-precision quantization of about 6.3 bits. Options are 2, 3, 4, 5, 6 and 8. (Only 6
 and 8 appear to be useful.)
 

--- a/doc/eval.md
+++ b/doc/eval.md
@@ -17,7 +17,7 @@ excessive for most benchmarks.
 
 - **-nfa / --no_flash_attn**: Don't use flash-attn.
 
-- **-nxf / --no_transformers**: Don't use xformers.
+- **-nxf / --no_xformers**: Don't use xformers.
 
 - **-fst / --fast_safetensors**: Use alternative loading mode. On Linux, this mode uses direct I/O and pinned
 buffers and can potentially load faster from very fast NVMe RAID arrays with a cold cache. On Windows, this


### PR DESCRIPTION
Two argument tables in the docs list long-flag names that do not match the actual parser.

### `doc/eval.md` — `--no_transformers` → `--no_xformers` (hard error)
The common-args table documents:
> - **-nxf / --no_transformers**: Don't use xformers.

But `exllamav2/model_init.py` defines `-nxf` as `--no_xformers`:
```python
parser.add_argument("-nxf", "--no_xformers", action = "store_true", ...)
```
There is no `--no_transformers`, so a user copying the long form hits `error: unrecognized arguments: --no_transformers` (exit 2). (`add_args` is shared by `eval/humaneval.py` and `eval/mmlu.py`.)

### `doc/convert.md` — `-hb / --bits` → `-hb / --head_bits` (silent wrong option)
The table lists:
> - **-hb / --bits *int***: Number of bits for the lm_head (output) layer of the model. Default is 6 ...

`exllamav2/conversion/convert_exl2.py` defines these as **two different** flags:
```python
parser.add_argument("-b",  "--bits",      type = float, default = 4.125, ...)  # decoder bpw
parser.add_argument("-hb", "--head_bits", type = int,   default = 6,     ...)  # head layer
```
So `-hb` is `--head_bits`, not `--bits` (note the description’s "Default is 6" matches `--head_bits`, not `--bits`’ 4.125). The same table already documents `-b / --bits` a few lines above, so the `-hb / --bits` pairing is a copy error — a user following it with `--bits` would silently set the decoder bitrate instead of the head bitrate.

Docs-only, two lines.